### PR TITLE
v0.0.86

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,4 @@ tailwind.config.js
 webview.config.js
 .demo
 .github
+scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Optimized package size
 - [#63](https://github.com/estruyf/vscode-demo-time/issues/63): Added completion and hover panel support for the frontmatter of the markdown slides
 - [#69](https://github.com/estruyf/vscode-demo-time/issues/69): Added the functionality to export the slides to a PDF file
+- [#72](https://github.com/estruyf/vscode-demo-time/issues/72): Moved the custom theme property from the demo JSON to the slide's frontmatter
 
 ## [0.0.85] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.0.86] - 2025-03-19
+## [0.0.86] - 2025-03-20
 
 - Optimized package size
 - [#63](https://github.com/estruyf/vscode-demo-time/issues/63): Added completion and hover panel support for the frontmatter of the markdown slides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Optimized package size
 - [#63](https://github.com/estruyf/vscode-demo-time/issues/63): Added completion and hover panel support for the frontmatter of the markdown slides
+- [#69](https://github.com/estruyf/vscode-demo-time/issues/69): Added the functionality to export the slides to a PDF file
 
 ## [0.0.85] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.0.86] - 2025-03-19
+
+- Optimized package size
+- [#63](https://github.com/estruyf/vscode-demo-time/issues/63): Added completion and hover panel support for the frontmatter of the markdown slides
+
 ## [0.0.85] - 2025-03-18
 
 - [#58](https://github.com/estruyf/vscode-demo-time/issues/58): Support theme changes in Shiki codeblocks on slides

--- a/assets/styles/export.css
+++ b/assets/styles/export.css
@@ -1,0 +1,170 @@
+@media print {
+  @page {
+    size: 960px 540px landscape;
+    margin: 0;
+  }
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  .slide {
+    page-break-after: always;
+    page-break-inside: avoid;
+    height: 540px;
+    width: 960px;
+    overflow: hidden;
+  }
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.slide {
+  background-color: var(--vscode-editor-background, #fff);
+  border: 1px solid var(--vscode-panel-border, #e0e0e0);
+  color: var(--vscode-editor-foreground, #333);
+  min-height: 540px;
+  width: 960px;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  font-size: var(--vscode-editor-font-size, 1.1em);
+  line-height: 1.5;
+  font-weight: normal;
+
+  & > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem /* 16px */ * calc(1 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem /* 16px */ * var(--tw-space-y-reverse));
+  }
+}
+
+.slide * {
+  color: var(--vscode-editor-foreground, #333);
+}
+
+h1 {
+  font-size: 2.25rem /* 36px */;
+  line-height: 2.5rem /* 40px */;
+  background-color: var(--vscode-editor-background, #fff);
+  color: var(--vscode-editor-foreground, #333);
+}
+
+h2 {
+  font-size: 1.875rem /* 30px */;
+  line-height: 2.25rem /* 36px */;
+  background-color: var(--vscode-editor-background, #fff);
+  color: var(--vscode-editor-foreground, #333);
+}
+
+h3 {
+  font-size: 1.5rem /* 24px */;
+  line-height: 2rem /* 32px */;
+  background-color: var(--vscode-editor-background, #fff);
+  color: var(--vscode-editor-foreground, #333);
+}
+
+h4 {
+  font-size: 1.25rem /* 20px */;
+  line-height: 1.75rem /* 28px */;
+  background-color: var(--vscode-editor-background, #fff);
+  color: var(--vscode-editor-foreground, #333);
+}
+
+h5 {
+  font-size: 1.125rem /* 18px */;
+  line-height: 1.75rem /* 28px */;
+  background-color: var(--vscode-editor-background, #fff);
+  color: var(--vscode-editor-foreground, #333);
+}
+
+p {
+  line-height: 1.625;
+  opacity: 0.8;
+
+  &:has(> img),
+  &:has(> a) {
+    opacity: 1;
+  }
+}
+
+a {
+  color: var(--vscode-textLink-foreground, #007acc);
+  text-decoration: underline;
+
+  &:hover {
+    color: var(--vscode-textLink-activeForeground, #005a9e);
+  }
+}
+
+ul,
+ol {
+  margin-left: 1.5rem /* 24px */;
+
+  li {
+    margin-bottom: 0.5rem /* 8px */;
+  }
+
+  ul,
+  ol {
+    margin-top: 0.5rem /* 8px */;
+  }
+}
+
+ul {
+  list-style-type: disc;
+}
+
+ol {
+  list-style-type: decimal;
+}
+
+blockquote {
+  background-color: var(--vscode-textBlockQuote-background, #f0f0f0);
+  border-color: var(--vscode-textBlockQuote-border, #ddd);
+  border-left-width: 4px;
+  padding: 0.5rem /* 8px */;
+}
+
+pre {
+  background: var(--vscode-editor-background);
+  border-radius: 4px;
+  overflow: auto;
+  max-width: 100%;
+  margin: 1.5rem 0;
+
+  code {
+    padding: 0 !important;
+    white-space: pre-wrap;
+    background: var(--vscode-editor-background);
+  }
+}
+
+code {
+  font-family: var(--vscode-editor-font-size, ui-sans-serif), ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+img {
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+  color: inherit;
+}
+
+th,
+td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+  color: inherit;
+}

--- a/assets/styles/export.css
+++ b/assets/styles/export.css
@@ -10,8 +10,6 @@
   .slide {
     page-break-after: always;
     page-break-inside: avoid;
-    height: 540px;
-    width: 960px;
     overflow: hidden;
   }
 }
@@ -26,6 +24,7 @@ body {
   background-color: var(--vscode-editor-background, #fff);
   border: 1px solid var(--vscode-panel-border, #e0e0e0);
   color: var(--vscode-editor-foreground, #333);
+  height: 540px;
   min-height: 540px;
   width: 960px;
   display: flex;
@@ -167,4 +166,81 @@ td {
   padding: 0.5rem;
   text-align: left;
   color: inherit;
+}
+
+/* Layouts */
+.slide__container,
+.slide__layout {
+  @apply h-full w-full;
+}
+
+div.intro {
+  @apply flex flex-col items-center justify-center text-center;
+
+  h1 {
+    @apply text-6xl;
+  }
+
+  p {
+    @apply text-base opacity-70;
+  }
+}
+
+div.quote {
+  @apply flex flex-col items-start justify-center text-center;
+
+  h1 {
+    @apply text-5xl;
+  }
+
+  p {
+    @apply text-base opacity-50;
+  }
+}
+
+div.section {
+  @apply flex flex-col items-center justify-center text-center;
+
+  h1 {
+    @apply text-6xl;
+  }
+
+  h2 {
+    @apply text-3xl opacity-80;
+  }
+
+  p {
+    @apply text-base opacity-75;
+  }
+}
+
+div.image {
+  @apply w-full h-full bg-cover bg-center bg-no-repeat;
+}
+
+div.image-left {
+  @apply grid grid-cols-2 auto-rows-fr gap-4;
+
+  .slide__image_left {
+    @apply w-full h-full bg-cover bg-center;
+  }
+}
+
+div.image-right {
+  @apply grid grid-cols-2 auto-rows-fr gap-4;
+
+  .slide__image_right {
+    @apply w-full h-full bg-cover bg-center;
+  }
+}
+
+div.two-columns {
+  .slide__content {
+    @apply grid grid-cols-2 gap-4;
+  }
+
+  .slide__left,
+  .slide__right {
+    @apply w-full space-y-4 !mt-0;
+  }
 }

--- a/assets/styles/print.css
+++ b/assets/styles/print.css
@@ -1,0 +1,104 @@
+@media print {
+  @page {
+    size: 960px 540px landscape;
+    margin: 0;
+  }
+
+  .slide {
+    page-break-after: always;
+    page-break-inside: avoid;
+    overflow: hidden;
+  }
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.slide {
+  background-color: var(--vscode-editor-background, #fff);
+  border: 1px solid var(--vscode-panel-border, #e0e0e0);
+  color: var(--vscode-editor-foreground, #333);
+  height: 540px;
+  min-height: 540px;
+  width: 960px;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  font-size: var(--vscode-editor-font-size, 1.1em);
+  line-height: 1.5;
+  font-weight: normal;
+}
+
+code {
+  font-family: var(--vscode-editor-font-size, ui-sans-serif), ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+blockquote {
+  p {
+    margin-bottom: 0 !important;
+  }
+}
+
+code {
+  color: var(--vscode-textPreformat-foreground);
+  background-color: var(--vscode-textPreformat-background);
+  padding: 1px 3px;
+  border-radius: 4px;
+}
+
+pre code {
+  padding: 0 !important;
+  white-space: pre-wrap;
+  background: var(--vscode-editor-background);
+}
+
+.slide__container,
+.slide__layout {
+  @apply h-full w-full;
+}
+
+.slide__content {
+  @apply h-full w-full text-base;
+
+  .slide__content__inner {
+    @apply h-full w-full;
+  }
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+  color: inherit;
+}
+
+th,
+td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+  color: inherit;
+}
+
+/* Layouts */
+div.image {
+  @apply w-full h-full bg-cover bg-center bg-no-repeat;
+}
+
+.image-left,
+.image-right {
+  @apply grid grid-cols-2 w-full h-full auto-rows-fr;
+}
+
+.slide__image_left,
+.slide__image_right {
+  @apply w-full h-full bg-cover bg-center;
+}

--- a/assets/styles/themes/default.css
+++ b/assets/styles/themes/default.css
@@ -1,0 +1,251 @@
+/* Default Theme */
+.slide.default {
+  --demotime-color: var(--vscode-editor-foreground);
+  --demotime-background: var(--vscode-editor-background);
+
+  --demotime-heading-color: var(--vscode-editor-foreground);
+  --demotime-heading-background: var(--vscode-editor-background);
+
+  --demotime-font-size: var(--vscode-editor-font-size, 1.1em);
+
+  --demotime-link-color: var(--vscode-textLink-foreground);
+  --demotime-link-active-color: var(--vscode-textLink-activeForeground);
+
+  --demotime-blockquote-border: var(--vscode-textBlockQuote-border);
+  --demotime-blockquote-background: var(--vscode-textBlockQuote-background);
+
+  --demotime-default-background: var(--demotime-background);
+  --demotime-default-color: var(--demotime-color);
+  --demotime-default-heading-color: var(--demotime-heading-color);
+  --demotime-default-heading-background: var(--demotime-heading-background);
+
+  --demotime-intro-background: var(--demotime-background);
+  --demotime-intro-color: var(--demotime-color);
+  --demotime-intro-heading-color: var(--demotime-heading-color);
+  --demotime-intro-heading-background: var(--demotime-heading-background);
+
+  --demotime-quote-background: var(--demotime-background);
+  --demotime-quote-color: var(--demotime-color);
+  --demotime-quote-heading-color: var(--demotime-heading-color);
+  --demotime-quote-heading-background: var(--demotime-heading-background);
+
+  --demotime-section-background: var(--demotime-background);
+  --demotime-section-color: var(--demotime-color);
+  --demotime-section-heading-color: var(--demotime-heading-color);
+  --demotime-section-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-left-background: var(--demotime-background);
+  --demotime-image-left-color: var(--demotime-color);
+  --demotime-image-left-heading-color: var(--demotime-heading-color);
+  --demotime-image-left-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-right-background: var(--demotime-background);
+  --demotime-image-right-color: var(--demotime-color);
+  --demotime-image-right-heading-color: var(--demotime-heading-color);
+  --demotime-image-right-heading-background: var(--demotime-heading-background);
+
+  --demotime-two-columns-background: var(--demotime-background);
+  --demotime-two-columns-color: var(--demotime-color);
+  --demotime-two-columns-heading-color: var(--demotime-heading-color);
+  --demotime-two-columns-heading-background: var(--demotime-heading-background);
+
+  background: var(--demotime-background);
+  color: var(--demotime-color);
+  font-size: var(--demotime-font-size);
+
+  .slide__content__inner {
+    @apply p-8 space-y-4;
+  }
+
+  h1 {
+    @apply text-4xl;
+    color: var(--demotime-heading-color);
+    background: var(--demotime-heading-background);
+  }
+
+  h2 {
+    @apply text-3xl;
+    color: var(--demotime-heading-color);
+    background: var(--demotime-heading-background);
+  }
+
+  h3 {
+    @apply text-2xl;
+    color: var(--demotime-heading-color);
+    background: var(--demotime-heading-background);
+  }
+
+  h4 {
+    @apply text-xl;
+    color: var(--demotime-heading-color);
+    background: var(--demotime-heading-background);
+  }
+
+  h5 {
+    @apply text-lg;
+    color: var(--demotime-heading-color);
+    background: var(--demotime-heading-background);
+  }
+
+  p {
+    @apply leading-relaxed opacity-80;
+
+    &:has(> img),
+    &:has(> a) {
+      @apply opacity-100;
+    }
+  }
+
+  a {
+    @apply text-[var(--demotime-link-color)] underline;
+
+    &:hover {
+      @apply text-[var(--demotime-link-active-color)];
+    }
+  }
+
+  ul,
+  ol {
+    @apply ml-6;
+
+    li {
+      @apply mb-2;
+    }
+
+    ul,
+    ol {
+      @apply mt-2;
+    }
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  img {
+  }
+
+  blockquote {
+    @apply border-l-4 p-2 border-[var(--demotime-blockquote-border)] bg-[var(--demotime-blockquote-background)];
+  }
+
+  .default {
+    background: var(--demotime-default-background);
+    color: var(--demotime-default-color);
+
+    h1 {
+      color: var(--demotime-default-heading-color);
+      background: var(--demotime-default-heading-background);
+    }
+  }
+
+  .intro {
+    background: var(--demotime-intro-background);
+    color: var(--demotime-intro-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+
+    h1 {
+      @apply text-6xl;
+      color: var(--demotime-intro-heading-color);
+      background: var(--demotime-intro-heading-background);
+    }
+
+    p {
+      @apply text-base opacity-70;
+    }
+  }
+
+  .quote {
+    background: var(--demotime-quote-background);
+    color: var(--demotime-quote-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-start justify-center text-center;
+    }
+
+    h1 {
+      @apply text-5xl;
+      color: var(--demotime-quote-heading-color);
+      background: var(--demotime-quote-heading-background);
+    }
+
+    p {
+      @apply text-base opacity-50;
+    }
+  }
+
+  .section {
+    background: var(--demotime-section-background);
+    color: var(--demotime-section-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+
+    h1 {
+      @apply text-6xl;
+      color: var(--demotime-section-heading-color);
+      background: var(--demotime-section-heading-background);
+    }
+
+    h2 {
+      @apply text-3xl opacity-80;
+    }
+
+    p {
+      @apply text-base opacity-75;
+    }
+  }
+
+  .image {
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+  }
+
+  .image-left {
+    background: var(--demotime-image-left-background);
+    color: var(--demotime-image-left-color);
+
+    h1 {
+      color: var(--demotime-image-left-heading-color);
+      background: var(--demotime-image-left-heading-background);
+    }
+  }
+
+  .image-right {
+    background: var(--demotime-image-right-background);
+    color: var(--demotime-image-right-color);
+
+    h1 {
+      color: var(--demotime-image-right-heading-color);
+      background: var(--demotime-image-right-heading-background);
+    }
+  }
+
+  .two-columns {
+    background: var(--demotime-two-columns-background);
+    color: var(--demotime-two-columns-color);
+
+    .slide__content__inner {
+      @apply w-full grid grid-cols-2 gap-4 space-y-0;
+    }
+
+    .slide__left,
+    .slide__right {
+      @apply w-full space-y-4;
+    }
+
+    h1 {
+      color: var(--demotime-two-columns-heading-color);
+      background: var(--demotime-two-columns-heading-background);
+    }
+  }
+}

--- a/assets/styles/themes/minimal.css
+++ b/assets/styles/themes/minimal.css
@@ -1,0 +1,243 @@
+/* Minimal Theme */
+.slide.minimal {
+  --demotime-color: var(--vscode-editor-foreground);
+  --demotime-background: var(--vscode-editor-background);
+
+  --demotime-heading-color: var(--vscode-editor-background);
+  --demotime-heading-background: var(--vscode-editor-foreground);
+
+  --demotime-font-size: var(--vscode-editor-font-size, 1.1em);
+
+  --demotime-link-color: var(--vscode-textLink-foreground);
+  --demotime-link-active-color: var(--vscode-textLink-activeForeground);
+
+  --demotime-blockquote-border: var(--vscode-textBlockQuote-border);
+  --demotime-blockquote-background: var(--vscode-textBlockQuote-background);
+
+  --demotime-default-background: var(--demotime-background);
+  --demotime-default-color: var(--demotime-color);
+  --demotime-default-heading-color: var(--demotime-heading-color);
+  --demotime-default-heading-background: var(--demotime-heading-background);
+
+  --demotime-intro-background: var(--demotime-background);
+  --demotime-intro-color: var(--demotime-color);
+  --demotime-intro-heading-color: var(--demotime-heading-color);
+  --demotime-intro-heading-background: var(--demotime-heading-background);
+
+  --demotime-quote-background: var(--demotime-background);
+  --demotime-quote-color: var(--demotime-color);
+  --demotime-quote-heading-color: var(--demotime-heading-color);
+  --demotime-quote-heading-background: var(--demotime-heading-background);
+
+  --demotime-section-background: var(--demotime-background);
+  --demotime-section-color: var(--demotime-color);
+  --demotime-section-heading-color: var(--demotime-heading-color);
+  --demotime-section-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-left-background: var(--demotime-background);
+  --demotime-image-left-color: var(--demotime-color);
+  --demotime-image-left-heading-color: var(--demotime-heading-color);
+  --demotime-image-left-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-right-background: var(--demotime-background);
+  --demotime-image-right-color: var(--demotime-color);
+  --demotime-image-right-heading-color: var(--demotime-heading-color);
+  --demotime-image-right-heading-background: var(--demotime-heading-background);
+
+  --demotime-two-columns-background: var(--demotime-background);
+  --demotime-two-columns-color: var(--demotime-color);
+  --demotime-two-columns-heading-color: var(--demotime-heading-color);
+  --demotime-two-columns-heading-background: var(--demotime-heading-background);
+
+  background: var(--demotime-background);
+  color: var(--demotime-color);
+  font-size: var(--demotime-font-size);
+
+  .slide__content__inner {
+    @apply p-8 space-y-4;
+  }
+
+  h1 {
+    @apply text-4xl p-4;
+    color: var(--demotime-heading-color);
+    background: var(--demotime-heading-background);
+  }
+
+  h2 {
+    @apply text-3xl;
+  }
+
+  h3 {
+    @apply text-2xl;
+  }
+
+  h4 {
+    @apply text-xl;
+  }
+
+  h5 {
+    @apply text-lg;
+  }
+
+  p {
+    @apply leading-relaxed opacity-80;
+
+    &:has(> img),
+    &:has(> a) {
+      @apply opacity-100;
+    }
+  }
+
+  a {
+    @apply text-[var(--demotime-link-color)] underline;
+
+    &:hover {
+      @apply text-[var(--demotime-link-active-color)];
+    }
+  }
+
+  ul,
+  ol {
+    @apply ml-6;
+
+    li {
+      @apply mb-2;
+    }
+
+    ul,
+    ol {
+      @apply mt-2;
+    }
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  img {
+  }
+
+  blockquote {
+    @apply border-l-4 p-2 border-[var(--demotime-blockquote-border)] bg-[var(--demotime-blockquote-background)];
+  }
+
+  .default {
+    background: var(--demotime-default-background);
+    color: var(--demotime-default-color);
+
+    h1 {
+      color: var(--demotime-default-heading-color);
+      background: var(--demotime-default-heading-background);
+    }
+  }
+
+  .intro {
+    background: var(--demotime-intro-background);
+    color: var(--demotime-intro-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+
+    h1 {
+      @apply text-6xl;
+      color: var(--demotime-intro-heading-color);
+      background: var(--demotime-intro-heading-background);
+    }
+
+    p {
+      @apply text-base opacity-70;
+    }
+  }
+
+  .quote {
+    background: var(--demotime-quote-background);
+    color: var(--demotime-quote-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-start justify-center text-center;
+    }
+
+    h1 {
+      @apply text-5xl;
+      color: var(--demotime-quote-heading-color);
+      background: var(--demotime-quote-heading-background);
+    }
+
+    p {
+      @apply text-base opacity-50;
+    }
+  }
+
+  .section {
+    background: var(--demotime-section-background);
+    color: var(--demotime-section-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+
+    h1 {
+      @apply text-6xl;
+      color: var(--demotime-section-heading-color);
+      background: var(--demotime-section-heading-background);
+    }
+
+    h2 {
+      @apply text-3xl opacity-80;
+    }
+
+    p {
+      @apply text-base opacity-75;
+    }
+  }
+
+  .image {
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+  }
+
+  .image-left {
+    background: var(--demotime-image-left-background);
+    color: var(--demotime-image-left-color);
+
+    h1 {
+      color: var(--demotime-image-left-heading-color);
+      background: var(--demotime-image-left-heading-background);
+    }
+  }
+
+  .image-right {
+    background: var(--demotime-image-right-background);
+    color: var(--demotime-image-right-color);
+
+    h1 {
+      color: var(--demotime-image-right-heading-color);
+      background: var(--demotime-image-right-heading-background);
+    }
+  }
+
+  .two-columns {
+    background: var(--demotime-two-columns-background);
+    color: var(--demotime-two-columns-color);
+
+    .slide__content__inner {
+      @apply w-full grid grid-cols-2 gap-4 space-y-0;
+    }
+
+    .slide__left,
+    .slide__right {
+      @apply w-full space-y-4;
+    }
+
+    h1 {
+      color: var(--demotime-two-columns-heading-color);
+      background: var(--demotime-two-columns-heading-background);
+    }
+  }
+}

--- a/assets/styles/themes/monomi.css
+++ b/assets/styles/themes/monomi.css
@@ -1,0 +1,286 @@
+/* 
+  Monomi Theme - Based on: https://github.com/estruyf/slidev-theme-the-unnamed
+*/
+.slide.monomi {
+  --demotime-color: var(--vscode-editor-foreground);
+  --demotime-background: var(--vscode-editor-background);
+  
+  --demotime-heading-color: var(--vscode-editor-background);
+  --demotime-heading-background: var(--vscode-editor-foreground);
+  --demotime-heading-font-weight: 900;
+
+  --demotime-font-size: var(--vscode-editor-font-size, 1.1em);
+
+  --demotime-bordered: 0
+
+  --demotime-link-color: var(--vscode-textLink-foreground);
+  --demotime-link-active-color: var(--vscode-textLink-activeForeground);
+
+  --demotime-code-background: var(--vscode-editor-background);
+  --demotime-code-border: var(--vscode-panel-border);
+
+  --demotime-blockquote-border: var(--vscode-textBlockQuote-border);
+  --demotime-blockquote-background: var(--vscode-textBlockQuote-background);
+
+  --demotime-default-background: var(--demotime-background);
+  --demotime-default-color: var(--demotime-color);
+  --demotime-default-heading-color: var(--demotime-heading-color);
+  --demotime-default-heading-background: var(--demotime-heading-background);
+
+  --demotime-intro-background: var(--demotime-background);
+  --demotime-intro-color: var(--demotime-color);
+  --demotime-intro-heading-color: var(--demotime-heading-color);
+  --demotime-intro-heading-background: var(--demotime-heading-background);
+
+  --demotime-quote-background: var(--demotime-background);
+  --demotime-quote-color: var(--demotime-color);
+  --demotime-quote-heading-color: var(--demotime-heading-color);
+  --demotime-quote-heading-background: var(--demotime-heading-background);
+
+  --demotime-section-background: var(--demotime-background);
+  --demotime-section-color: var(--demotime-background);
+  --demotime-section-heading-color: var(--demotime-heading-color);
+  --demotime-section-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-left-background: var(--demotime-background);
+  --demotime-image-left-color: var(--demotime-color);
+  --demotime-image-left-heading-color: var(--demotime-heading-color);
+  --demotime-image-left-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-right-background: var(--demotime-background);
+  --demotime-image-right-color: var(--demotime-color);
+  --demotime-image-right-heading-color: var(--demotime-heading-color);
+  --demotime-image-right-heading-background: var(--demotime-heading-background);
+
+  --demotime-two-columns-background: var(--demotime-background);
+  --demotime-two-columns-color: var(--demotime-color);
+  --demotime-two-columns-heading-color: var(--demotime-heading-color);
+  --demotime-two-columns-heading-background: var(--demotime-heading-background);
+
+  background: var(--demotime-background);
+  color: var(--demotime-color);
+  font-size: var(--demotime-font-size);
+
+  .slide__content__inner {
+    @apply p-8 space-y-4;
+  }
+
+  h1 {
+    @apply text-4xl p-2 w-auto inline-block;
+    background: var(--demotime-heading-background);
+    color: var(--demotime-heading-color);
+    font-weight: var(--demotime-heading-font-weight);
+
+    border: calc(2 * var(--demotime-bordered)) solid var(--demotime-background);
+    outline: var(--demotime-bordered) solid var(--demotime-heading-background);
+
+    margin-left: 0;
+
+    &:not(:first-child) {
+      @apply mt-8;
+    }
+  }
+
+  h2 {
+    @apply text-3xl pt-4 pb-2;
+  }
+
+  h3 {
+    @apply text-2xl;
+  }
+
+  h4 {
+    @apply text-xl;
+  }
+
+  h5 {
+    @apply text-lg;
+  }
+
+  p {
+    @apply leading-relaxed;
+  }
+
+  a {
+    @apply text-[var(--demotime-link-foreground)] underline;
+
+    &:hover {
+      @apply text-[var(--demotime-link-activeForeground)];
+    }
+  }
+
+  ul,
+  ol {
+    @apply ml-6;
+
+    li {
+      @apply mb-2;
+    }
+
+    ul,
+    ol {
+      @apply mt-2;
+    }
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  img {
+  }
+
+  blockquote {
+    @apply border-l-4 p-2 border-[var(--demotime-blockquote-border)] bg-[var(--demotime-blockquote-background)];
+  }
+
+  .default {
+    background: var(--demotime-default-background);
+    color: var(--demotime-default-color);
+
+    h1 {
+      color: var(--demotime-default-heading-color);
+      background: var(--demotime-default-heading-background);
+    }
+  }
+
+  .intro {
+    background: var(--demotime-intro-background);
+    color: var(--demotime-intro-color);
+
+    .slide__content__inner {
+      @apply w-full flex flex-col items-center justify-center;
+    }
+
+    h1 {
+      @apply text-5xl w-4/6 p-4 inline-block leading-tight mx-auto;
+      color: var(--demotime-intro-heading-color);
+      background: var(--demotime-intro-heading-background);
+      min-height: 25%;
+    }
+
+    h1 + h2,
+    h1 + p {
+      @apply text-2xl -mt-2 mb-4 w-4/6 mx-auto;
+      color: var(--slidev-intro-heading-background);
+      padding-left: calc(1rem + (2 * var(--slidev-theme-bordered)));
+    }
+
+    p + h2,
+    ul + h2,
+    table + h2 {
+      @apply mt-10;
+    }
+  }
+
+  .quote {
+    background: var(--demotime-quote-background);
+    color: var(--demotime-quote-color);
+
+    .slide__content {
+      @apply w-full flex flex-col justify-center;
+
+      .slide__content__inner {
+        @apply p-8 w-full h-auto;
+      }
+    }
+
+    h1 {
+      @apply text-5xl mb-0;
+      color: var(--demotime-quote-heading-color);
+      background: var(--demotime-quote-heading-background);
+    }
+  }
+
+  .section {
+    background: var(--demotime-section-background);
+    color: var(--demotime-section-color);
+
+    .slide__content {
+      @apply px-0 w-full h-full flex items-center;
+
+      .slide__content__inner {
+        @apply p-8 w-full h-auto text-center;
+        background: var(--demotime-section-heading-background);
+        color: var(--demotime-section-heading-color);
+    
+        border-bottom: calc(2 * var(--demotime-bordered)) solid
+          var(--demotime-background);
+        border-top: calc(2 * var(--demotime-bordered)) solid
+          var(--demotime-background);
+        outline: var(--demotime-bordered) solid
+          var(--demotime-section-heading-background);
+      }
+    }
+
+    h1 {
+      @apply text-5xl mb-0;
+      background: var(--demotime-section-heading-background);
+      color: var(--demotime-section-heading-color);
+
+      border: 0;
+      outline: 0;
+    }
+
+    p {
+      color: var(--demotime-section-color);
+    }
+  }
+
+  .image {
+    .slide__content {
+      @apply w-full flex flex-col items-center justify-center text-center;
+    }
+  }
+
+  .image-left {
+    background: var(--demotime-image-left-background);
+    color: var(--demotime-image-left-color);
+
+    .slide__content {
+      @apply w-full;
+    }
+
+    h1 {
+      color: var(--demotime-image-left-heading-color);
+      background: var(--demotime-image-left-heading-background);
+    }
+  }
+
+  .image-right {
+    background: var(--demotime-image-right-background);
+    color: var(--demotime-image-right-color);
+
+    .slide__content {
+      @apply w-full;
+    }
+
+    h1 {
+      color: var(--demotime-image-right-heading-color);
+      background: var(--demotime-image-right-heading-background);
+    }
+  }
+
+  .two-columns {
+    background: var(--demotime-two-columns-background);
+    color: var(--demotime-two-columns-color);
+
+    .slide__content__inner {
+      @apply w-full grid grid-cols-2 gap-4 space-y-0;
+    }
+
+    .slide__left,
+    .slide__right {
+      @apply w-full space-y-4;
+    }
+
+    h1 {
+      color: var(--demotime-two-columns-heading-color);
+      background: var(--demotime-two-columns-heading-background);
+    }
+  }
+}

--- a/assets/styles/themes/unnamed.css
+++ b/assets/styles/themes/unnamed.css
@@ -1,0 +1,294 @@
+/* 
+  The unnamed Theme - Based on: https://github.com/estruyf/slidev-theme-the-unnamed
+*/
+.slide.unnamed {
+  --demotime-color: var(--vscode-editor-foreground);
+  --demotime-background: var(--vscode-panel-background);
+
+  --demotime-font-size: var(--vscode-editor-font-size, 1.1em);
+
+  --demotime-heading-color: var(--vscode-activityBarBadge-foreground);
+  --demotime-heading-background: var(--vscode-activityBarBadge-background);
+  --demotime-header-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
+
+  --demotime-link-color: var(--vscode-textLink-foreground);
+  --demotime-link-active-color: var(--vscode-textLink-activeForeground);
+
+  --demotime-code-background: var(--vscode-editor-background);
+  --demotime-code-border: var(--vscode-panel-border);
+
+  --demotime-quote-border: var(--vscode-textBlockQuote-border);
+  --demotime-quote-background: var(--vscode-textBlockQuote-background);
+
+  --demotime-default-background: var(--demotime-background);
+  --demotime-default-color: var(--demotime-color);
+  --demotime-default-heading-color: var(--demotime-heading-color);
+  --demotime-default-heading-background: var(--demotime-heading-background);
+
+  --demotime-intro-background: var(--demotime-background);
+  --demotime-intro-color: var(--demotime-color);
+  --demotime-intro-heading-color: var(--demotime-heading-color);
+  --demotime-intro-heading-background: var(--demotime-heading-background);
+
+  --demotime-quote-background: var(--demotime-background);
+  --demotime-quote-color: var(--demotime-color);
+  --demotime-quote-heading-color: var(--demotime-heading-color);
+  --demotime-quote-heading-background: var(--demotime-heading-background);
+
+  --demotime-section-background: var(--demotime-background);
+  --demotime-section-color: var(--demotime-color);
+  --demotime-section-heading-color: var(--demotime-heading-color);
+  --demotime-section-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-left-background: var(--demotime-background);
+  --demotime-image-left-color: var(--demotime-color);
+  --demotime-image-left-heading-color: var(--demotime-heading-color);
+  --demotime-image-left-heading-background: var(--demotime-heading-background);
+
+  --demotime-image-right-background: var(--demotime-background);
+  --demotime-image-right-color: var(--demotime-color);
+  --demotime-image-right-heading-color: var(--demotime-heading-color);
+  --demotime-image-right-heading-background: var(--demotime-heading-background);
+
+  --demotime-two-columns-background: var(--demotime-background);
+  --demotime-two-columns-color: var(--demotime-color);
+  --demotime-two-columns-heading-color: var(--demotime-heading-color);
+  --demotime-two-columns-heading-background: var(--demotime-heading-background);
+
+  background: var(--demotime-background);
+  color: var(--demotime-color);
+  font-size: var(--demotime-font-size);
+
+  .slide__content__inner {
+    @apply p-8 space-y-4;
+  }
+
+  h1 {
+    @apply text-4xl;
+    color: var(--demotime-heading-color);
+    display: inline-block;
+    padding: 0.25em;
+    position: relative;
+    margin-bottom: 0.5em;
+    z-index: 1;
+
+    &::before {
+      background: var(--demotime-heading-background);
+      box-shadow: var(--demotime-header-shadow);
+      content: " ";
+      display: block;
+      position: absolute;
+      width: calc(100%);
+      height: calc(100%);
+      margin-left: -0.25em;
+      margin-top: -0.25em;
+      z-index: -1;
+      transform: rotate(-1deg);
+    }
+  }
+
+  h2 {
+    @apply text-3xl;
+  }
+
+  h3 {
+    @apply text-2xl;
+  }
+
+  h4 {
+    @apply text-xl;
+  }
+
+  h5 {
+    @apply text-lg;
+  }
+
+  p {
+    @apply leading-relaxed opacity-80;
+
+    &:has(> img),
+    &:has(> a) {
+      @apply opacity-100;
+    }
+  }
+
+  a {
+    @apply text-[var(--demotime-link-color)] underline;
+
+    &:hover {
+      @apply text-[var(--demotime-link-active-color)];
+    }
+  }
+
+  ul,
+  ol {
+    @apply ml-6;
+
+    li {
+      @apply mb-2;
+    }
+
+    ul,
+    ol {
+      @apply mt-2;
+    }
+  }
+
+  ul {
+    @apply list-disc;
+  }
+
+  ol {
+    @apply list-decimal;
+  }
+
+  img {
+  }
+
+  blockquote {
+    @apply border-l-4 p-2 border-[var(--demotime-blockquote-border)] bg-[var(--demotime-blockquote-background)];
+  }
+
+  pre code {
+    @apply !p-4;
+    background: var(--demotime-code-background);
+    border: 1px solid var(--demotime-code-border);
+  }
+
+  .default {
+    background: var(--demotime-default-background);
+    color: var(--demotime-default-color);
+
+    h1 {
+      color: var(--demotime-default-heading-color);
+
+      &::before {
+        background: var(--demotime-default-heading-background);
+      }
+    }
+  }
+
+  .intro {
+    background: var(--demotime-intro-background);
+    color: var(--demotime-intro-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+
+    h1 {
+      @apply text-6xl;
+      color: var(--demotime-intro-heading-color);
+
+      &::before {
+        background: var(--demotime-intro-heading-background);
+      }
+    }
+
+    p {
+      @apply text-base opacity-70;
+    }
+  }
+
+  .quote {
+    background: var(--demotime-quote-background);
+    color: var(--demotime-quote-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-start justify-center text-center;
+    }
+
+    h1 {
+      @apply text-5xl;
+      color: var(--demotime-quote-heading-color);
+
+      &::before {
+        background: var(--demotime-quote-heading-background);
+      }
+    }
+
+    p {
+      @apply text-base opacity-50;
+    }
+  }
+
+  .section {
+    background: var(--demotime-section-background);
+    color: var(--demotime-section-color);
+
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+
+    h1 {
+      @apply text-6xl;
+      color: var(--demotime-section-heading-color);
+
+      &::before {
+        background: var(--demotime-section-heading-background);
+      }
+    }
+
+    h2 {
+      @apply text-3xl opacity-80;
+    }
+
+    p {
+      @apply text-base;
+    }
+  }
+
+  .image {
+    .slide__content__inner {
+      @apply flex flex-col items-center justify-center text-center;
+    }
+  }
+
+  .image-left {
+    background: var(--demotime-image-left-background);
+    color: var(--demotime-image-left-color);
+
+    h1 {
+      color: var(--demotime-image-left-heading-color);
+
+      &::before {
+        background: var(--demotime-image-left-heading-background);
+      }
+    }
+  }
+
+  .image-right {
+    background: var(--demotime-image-right-background);
+    color: var(--demotime-image-right-color);
+
+    h1 {
+      color: var(--demotime-image-right-heading-color);
+
+      &::before {
+        background: var(--demotime-image-right-heading-background);
+      }
+    }
+  }
+
+  .two-columns {
+    background: var(--demotime-two-columns-background);
+    color: var(--demotime-two-columns-color);
+
+    .slide__content__inner {
+      @apply w-full grid grid-cols-2 gap-4 space-y-0;
+    }
+
+    .slide__left,
+    .slide__right {
+      @apply w-full space-y-4;
+    }
+
+    h1 {
+      color: var(--demotime-two-columns-heading-color);
+
+      &::before {
+        background: var(--demotime-two-columns-heading-background);
+      }
+    }
+  }
+}

--- a/demotime.slide.schema.json
+++ b/demotime.slide.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Demo Time - Slide",
+  "type": "object",
+  "properties": {
+    "theme": {
+      "type": "string",
+      "enum": ["default", "minimal", "monomi", "unnamed"],
+      "description": "The theme of the slide."
+    },
+    "layout": {
+      "type": "string",
+      "enum": ["default", "intro", "section", "quote", "image", "image-left", "image-right", "two-columns"],
+      "description": "The layout of the slide."
+    },
+    "image": {
+      "type": "string",
+      "description": "The URL of the image for the slide."
+    }
+  },
+  "additionalProperties": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,6 @@
       "name": "vscode-demo-time",
       "version": "0.0.85",
       "license": "MIT",
-      "dependencies": {
-        "diff": "^7.0.0",
-        "rehype-pretty-code": "^0.14.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-react": "^8.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-rehype": "^11.1.1",
-        "vfile-matter": "^5.0.0"
-      },
       "devDependencies": {
         "@estruyf/vscode": "^1.1.0",
         "@types/cors": "^2.8.17",
@@ -33,6 +23,7 @@
         "autoprefixer": "^10.4.20",
         "cors": "^2.8.5",
         "css-loader": "^7.1.2",
+        "diff": "^7.0.0",
         "eslint": "^8.52.0",
         "express": "^4.21.2",
         "glob": "^10.3.10",
@@ -43,11 +34,18 @@
         "postcss-loader": "^8.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "rehype-pretty-code": "^0.14.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-react": "^8.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-rehype": "^11.1.1",
         "style-loader": "^4.0.0",
         "tailwindcss": "^3.4.16",
         "ts-loader": "^9.5.1",
         "tsup": "^8.0.1",
         "typescript": "^5.2.2",
+        "vfile-matter": "^5.0.0",
         "vscrui": "^0.2.0-beta.1229608",
         "webpack": "^5.97.1",
         "webpack-cli": "^5.1.4",
@@ -1056,6 +1054,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
       "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1071,6 +1070,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
       "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1083,6 +1083,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
       "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1094,6 +1095,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
       "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1104,6 +1106,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
       "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1114,6 +1117,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
       "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1125,6 +1129,7 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -1189,6 +1194,7 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -1224,12 +1230,14 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "node_modules/@types/estree-jsx": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
       "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -1275,6 +1283,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1305,6 +1314,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1326,6 +1336,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1438,6 +1449,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
@@ -1653,7 +1665,8 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.3.8",
@@ -2177,6 +2190,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2468,6 +2482,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2494,6 +2509,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2504,6 +2520,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2514,6 +2531,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2524,6 +2542,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2668,6 +2687,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3006,6 +3026,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3035,6 +3056,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
       "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -3137,6 +3159,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3162,6 +3185,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -3181,6 +3205,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
       "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3270,6 +3295,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
       "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3299,6 +3325,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3665,6 +3692,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
       "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3819,6 +3847,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -3895,6 +3924,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
       "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "format": "^0.2.0"
@@ -4067,6 +4097,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -4453,6 +4484,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
       "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4471,6 +4503,7 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
       "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4491,6 +4524,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -4504,6 +4538,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
       "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4529,6 +4564,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4553,6 +4589,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.3.tgz",
       "integrity": "sha512-pdpkP8YD4v+qMKn2lnKSiJvZvb3FunDmFYQvVOsoO08+eTNWdaWKPMrC5wwNICtU3dQWHhElj5Sf5jPEnv4qJg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -4580,6 +4617,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
       "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4599,6 +4637,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
       "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4609,6 +4648,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
       "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -4622,6 +4662,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -4635,6 +4676,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
       "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4679,6 +4721,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4911,6 +4954,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/internal-slot": {
@@ -4949,6 +4993,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4959,6 +5004,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
@@ -5112,6 +5158,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5197,6 +5244,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5784,6 +5832,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5815,6 +5864,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5834,6 +5884,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5850,6 +5901,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5862,6 +5914,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
       "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5886,6 +5939,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
       "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5904,6 +5958,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5916,6 +5971,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -5935,6 +5991,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5952,6 +6009,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5969,6 +6027,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5984,6 +6043,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6001,6 +6061,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6017,6 +6078,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
       "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -6035,6 +6097,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
       "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -6059,6 +6122,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
       "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
@@ -6077,6 +6141,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6091,6 +6156,7 @@
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
       "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -6112,6 +6178,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6133,6 +6200,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -6216,6 +6284,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
       "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6251,6 +6320,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
       "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6285,6 +6355,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
       "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fault": "^2.0.0",
@@ -6301,6 +6372,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -6321,6 +6393,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -6337,6 +6410,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -6357,6 +6431,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -6375,6 +6450,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -6392,6 +6468,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
@@ -6405,6 +6482,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -6422,6 +6500,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6443,6 +6522,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6465,6 +6545,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6485,6 +6566,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6507,6 +6589,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6529,6 +6612,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6549,6 +6633,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6568,6 +6653,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6589,6 +6675,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6609,6 +6696,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6628,6 +6716,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6650,6 +6739,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6666,6 +6756,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6682,6 +6773,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6701,6 +6793,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6720,6 +6813,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6741,6 +6835,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.4.tgz",
       "integrity": "sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6763,6 +6858,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6779,6 +6875,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
       "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6982,6 +7079,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -7376,6 +7474,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
       "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7497,6 +7596,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
@@ -7516,6 +7616,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/parse-json": {
@@ -7535,12 +7636,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/parse5": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
       "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
@@ -8026,6 +8129,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
       "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8265,6 +8369,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
       "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8275,6 +8380,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
       "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8286,6 +8392,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -8311,6 +8418,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
       "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -8326,6 +8434,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.0.tgz",
       "integrity": "sha512-hBeKF/Wkkf3zyUS8lal9RCUuhypDWLQc+h9UrP9Pav25FUm/AQAVh4m5gdvJxh4Oz+U+xKvdsV01p1LdvsZTiQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -8346,6 +8455,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
       "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -8361,6 +8471,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-8.0.0.tgz",
       "integrity": "sha512-vzo0YxYbB2HE+36+9HWXVdxNoNDubx63r5LBzpxBGVWM8s9mdnMdbmuJBAX6TTyuGdZjZix6qU3GcSuKCIWivw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -8376,6 +8487,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
       "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8392,6 +8504,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8410,6 +8523,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8426,6 +8540,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.1.tgz",
       "integrity": "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -8443,6 +8558,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -9024,6 +9140,7 @@
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
       "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9191,6 +9308,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9434,6 +9552,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -9519,6 +9638,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
       "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.4"
@@ -9827,6 +9947,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9837,6 +9958,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10103,6 +10225,7 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -10122,6 +10245,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10134,6 +10258,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -10147,6 +10272,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -10160,6 +10286,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -10173,6 +10300,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -10188,6 +10316,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
       "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -10293,6 +10422,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -10307,6 +10437,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
       "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -10321,6 +10452,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.0.tgz",
       "integrity": "sha512-jhPSqlj8hTSkTXOqyxbUeZAFFVq/iwu/jukcApEqc/7DOidaAth6rDc0Zgg0vWpzUnWkwFP7aK28l6nBmxMqdQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vfile": "^6.0.0",
@@ -10335,6 +10467,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
       "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -10385,6 +10518,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11098,6 +11232,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -11181,6 +11316,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-demo-time",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-demo-time",
-      "version": "0.0.85",
+      "version": "0.0.86",
       "license": "MIT",
       "devDependencies": {
         "@estruyf/vscode": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,10 @@
         "express": "^4.21.2",
         "glob": "^10.3.10",
         "jsonc-parser": "^3.3.1",
+        "mlly": "^1.7.4",
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
+        "playwright-chromium": "^1.51.1",
         "postcss": "^8.4.49",
         "postcss-loader": "^8.1.1",
         "react": "^18.3.1",
@@ -37,6 +39,7 @@
         "rehype-pretty-code": "^0.14.0",
         "rehype-raw": "^7.0.0",
         "rehype-react": "^8.0.0",
+        "rehype-stringify": "^10.0.1",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "remark-rehype": "^11.1.1",
@@ -50,10 +53,18 @@
         "webpack": "^5.97.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.0",
-        "webpack-manifest-plugin": "^5.0.0"
+        "webpack-manifest-plugin": "^5.0.1"
       },
       "engines": {
         "vscode": "^1.84.0"
+      },
+      "peerDependencies": {
+        "playwright-chromium": "^1.51.1"
+      },
+      "peerDependenciesMeta": {
+        "playwright-chromium": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2774,6 +2785,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -4566,7 +4584,6 @@
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -6970,6 +6987,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
     "node_modules/mocha": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
@@ -7725,6 +7755,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7835,6 +7872,48 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright-chromium": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.51.1.tgz",
+      "integrity": "sha512-IQpN8lgv/fx++WRxT8ITZylDwYAamd3Fv5H9g2AWsicp0N829L1oXHziK/6l9h/TMxioSTqc4ifPiZLS8nITxw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8476,6 +8555,22 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-jsx-runtime": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -10200,6 +10295,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -10859,19 +10961,20 @@
       }
     },
     "node_modules/webpack-manifest-plugin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-5.0.0.tgz",
-      "integrity": "sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-5.0.1.tgz",
+      "integrity": "sha512-xTlX7dC3hrASixA2inuWFMz6qHsNi6MT3Uiqw621sJjRTShtpMjbDYhPPZBwWUKdIYKIjSq9em6+uzWayf38aQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tapable": "^2.0.0",
         "webpack-sources": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "webpack": "^5.47.0"
+        "webpack": "^5.75.0"
       }
     },
     "node_modules/webpack-manifest-plugin/node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -321,6 +321,11 @@
         "title": "View slide",
         "category": "Demo Time",
         "icon": "$(preview)"
+      },
+      {
+        "command": "demo-time.exportToPdf",
+        "title": "Export slides to PDF",
+        "category": "Demo Time"
       }
     ],
     "menus": {
@@ -523,6 +528,14 @@
     "watch:preview": "webpack serve --mode development --config ./preview.config.js",
     "lint": "eslint src --ext ts"
   },
+  "peerDependencies": {
+    "playwright-chromium": "^1.51.1"
+  },
+  "peerDependenciesMeta": {
+    "playwright-chromium": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@estruyf/vscode": "^1.1.0",
     "@types/cors": "^2.8.17",
@@ -538,34 +551,36 @@
     "autoprefixer": "^10.4.20",
     "cors": "^2.8.5",
     "css-loader": "^7.1.2",
+    "diff": "^7.0.0",
     "eslint": "^8.52.0",
     "express": "^4.21.2",
     "glob": "^10.3.10",
     "jsonc-parser": "^3.3.1",
+    "mlly": "^1.7.4",
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
+    "playwright-chromium": "^1.51.1",
     "postcss": "^8.4.49",
     "postcss-loader": "^8.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "rehype-pretty-code": "^0.14.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-react": "^8.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-rehype": "^11.1.1",
     "style-loader": "^4.0.0",
     "tailwindcss": "^3.4.16",
     "ts-loader": "^9.5.1",
     "tsup": "^8.0.1",
     "typescript": "^5.2.2",
+    "vfile-matter": "^5.0.0",
     "vscrui": "^0.2.0-beta.1229608",
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.0",
-    "webpack-manifest-plugin": "^5.0.0",
-    "diff": "^7.0.0",
-    "rehype-pretty-code": "^0.14.0",
-    "rehype-raw": "^7.0.0",
-    "rehype-react": "^8.0.0",
-    "remark-frontmatter": "^5.0.0",
-    "remark-gfm": "^4.0.1",
-    "remark-rehype": "^11.1.1",
-    "vfile-matter": "^5.0.0"
-  },
-  "dependencies": {}
+    "webpack-manifest-plugin": "^5.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -325,7 +325,8 @@
       {
         "command": "demo-time.exportToPdf",
         "title": "Export slides to PDF",
-        "category": "Demo Time"
+        "category": "Demo Time",
+        "icon": "$(file-pdf)"
       }
     ],
     "menus": {
@@ -405,9 +406,14 @@
           "group": "navigation@2"
         },
         {
-          "command": "demo-time.collapseAll",
+          "command": "demo-time.exportToPdf",
           "when": "view == demo-time",
           "group": "navigation@3"
+        },
+        {
+          "command": "demo-time.collapseAll",
+          "when": "view == demo-time",
+          "group": "navigation@4"
         },
         {
           "command": "demo-time.createDemoFile",

--- a/package.json
+++ b/package.json
@@ -323,6 +323,12 @@
         "icon": "$(preview)"
       },
       {
+        "command": "demo-time.openSlidePreview",
+        "title": "Open slide preview",
+        "category": "Demo Time",
+        "icon": "$(preview)"
+      },
+      {
         "command": "demo-time.exportToPdf",
         "title": "Export slides to PDF",
         "category": "Demo Time",
@@ -471,6 +477,11 @@
           "command": "demo-time.docs",
           "when": "(editorLangId == jsonc || editorLangId == json) && resourceDirname =~ /\\.demo$/",
           "group": "navigation@1"
+        },
+        {
+          "command": "demo-time.openSlidePreview",
+          "when": "editorLangId == markdown && resourceDirname =~ /\\.demo/",
+          "group": "navigation@-1"
         },
         {
           "command": "demo-time.toggleSelectionHighlight",

--- a/package.json
+++ b/package.json
@@ -557,9 +557,7 @@
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.0",
-    "webpack-manifest-plugin": "^5.0.0"
-  },
-  "dependencies": {
+    "webpack-manifest-plugin": "^5.0.0",
     "diff": "^7.0.0",
     "rehype-pretty-code": "^0.14.0",
     "rehype-raw": "^7.0.0",
@@ -568,5 +566,6 @@
     "remark-gfm": "^4.0.1",
     "remark-rehype": "^11.1.1",
     "vfile-matter": "^5.0.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -539,6 +539,7 @@
     "compile:ext": "tsup --minify",
     "compile:wv": "webpack --mode production --config ./webview.config.js",
     "compile:preview": "webpack --mode production --config ./preview.config.js",
+    "compile:copy": "node ./scripts/copy-assets.mjs",
     "watch": "npm-run-all --parallel watch:*",
     "watch:ext": "tsup --watch",
     "watch:wv": "webpack serve --mode development --config ./webview.config.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-demo-time",
   "displayName": "Demo Time - Live demos & slides in VS Code",
   "description": "Script your coding demos to perfection and present slides — all within VS Code! No typos, no missteps—just flawless, stress-free presentations. Seamlessly execute each demo step and advance through slides like a pro, keeping your audience engaged without ever leaving your coding environment.",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "publisher": "eliostruyf",
   "galleryBanner": {
     "color": "#0D1321",

--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
         "command": "demo-time.openSlidePreview",
         "title": "Open slide preview",
         "category": "Demo Time",
-        "icon": "$(preview)"
+        "icon": "$(eye)"
       },
       {
         "command": "demo-time.exportToPdf",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,27 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const sourceDir = path.join('src', 'preview', 'themes');
+const destinationDir = path.join('assets', 'styles', 'themes');
+
+async function copyFiles(src, dest) {
+  try {
+    await fs.mkdir(dest, { recursive: true });
+    const files = await fs.readdir(src);
+
+    for (const file of files) {
+      const srcFile = path.join(src, file);
+      const destFile = path.join(dest, file);
+      const stat = await fs.stat(srcFile);
+
+      if (stat.isFile()) {
+        await fs.copyFile(srcFile, destFile);
+        console.log(`Copied: ${srcFile} -> ${destFile}`);
+      }
+    }
+  } catch (error) {
+    console.error('Error copying files:', error);
+  }
+}
+
+copyFiles(sourceDir, destinationDir);

--- a/src/constants/Command.ts
+++ b/src/constants/Command.ts
@@ -38,6 +38,8 @@ export const COMMAND = {
   // Slides
   createSlide: `${EXTENSION_NAME}.createSlide`,
   viewSlide: `${EXTENSION_NAME}.viewSlide`,
+  openSlidePreview: `${EXTENSION_NAME}.openSlidePreview`,
   togglePresentationView: `${EXTENSION_NAME}.togglePresentationView`,
   closePresentationView: `${EXTENSION_NAME}.closePresentationView`,
+  exportToPdf: `${EXTENSION_NAME}.exportToPdf`,
 };

--- a/src/constants/General.ts
+++ b/src/constants/General.ts
@@ -4,4 +4,6 @@ export const General = {
   snapshotsFolder: "snapshots",
   patchesFolder: "patches",
   slidesFolder: "slides",
+  htmlExportFile: "demotime.export.html",
+  pdfExportFile: "demotime.export.pdf",
 };

--- a/src/constants/SlideTheme.ts
+++ b/src/constants/SlideTheme.ts
@@ -1,0 +1,6 @@
+export enum SlideTheme {
+  default = "default",
+  minimal = "minimal",
+  monomi = "monomi",
+  unnamed = "unnamed",
+}

--- a/src/constants/WebViewMessages.ts
+++ b/src/constants/WebViewMessages.ts
@@ -11,6 +11,7 @@ export const WebViewMessages = {
     openNotes: "openNotes",
     // Preview
     getFileUri: "getFileUri",
+    parseFileUri: "parseFileUri",
     getStyles: "getStyles",
     getTheme: "getTheme",
     getSlideTheme: "getSlideTheme",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,5 +3,6 @@ export * from "./Config";
 export * from "./ContextKeys";
 export * from "./General";
 export * from "./SlideLayout";
+export * from "./SlideTheme";
 export * from "./StateKeys";
 export * from "./WebViewMessages";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
   Preview.register();
   PresenterView.register();
   FileProvider.register();
-  Slides.registerCommands();
+  Slides.register();
   NotesService.registerCommands();
   DemoApi.register();
   UriHandler.register();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { DemoPanel } from "./panels/DemoPanel";
 import { Preview } from "./preview/Preview";
 import { PresenterView } from "./presenterView/PresenterView";
 import { Config } from "./constants";
+import { PdfExportService } from "./services/PdfExportService";
 
 export async function activate(context: vscode.ExtensionContext) {
   Extension.getInstance(context);
@@ -38,6 +39,7 @@ export async function activate(context: vscode.ExtensionContext) {
   NotesService.registerCommands();
   DemoApi.register();
   UriHandler.register();
+  PdfExportService.register();
 
   console.log(`${Config.title} is active!`);
 }

--- a/src/models/Demos.ts
+++ b/src/models/Demos.ts
@@ -64,9 +64,12 @@ export interface IOpenWebsite {
   openInVSCode?: boolean;
 }
 
-export interface IImagePreview {
+export interface ISlidePreview {
   action: Action;
   path?: string;
+}
+
+export interface IImagePreview extends ISlidePreview {
   theme?: string;
 }
 

--- a/src/preview/Preview.ts
+++ b/src/preview/Preview.ts
@@ -100,6 +100,9 @@ export class Preview {
     if (command === WebViewMessages.toVscode.getFileUri && requestId) {
       const fileWebviewPath = getWebviewUrl(Preview.webview?.webview, Preview.crntFile);
       Preview.postRequestMessage(WebViewMessages.toVscode.getFileUri, requestId, fileWebviewPath);
+    } else if (command === WebViewMessages.toVscode.parseFileUri && requestId && payload) {
+      const fileWebviewPath = getWebviewUrl(Preview.webview?.webview, payload);
+      Preview.postRequestMessage(WebViewMessages.toVscode.getFileUri, requestId, fileWebviewPath);
     } else if (command === WebViewMessages.toVscode.getStyles && requestId) {
       const cssWebviewPath = Preview.crntCss ? getWebviewUrl(Preview.webview?.webview, Preview.crntCss) : undefined;
       Preview.postRequestMessage(WebViewMessages.toVscode.getStyles, requestId, cssWebviewPath);

--- a/src/preview/components/Markdown.tsx
+++ b/src/preview/components/Markdown.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { useRemark } from '../hooks/useRemark';
 import { transformImageUrl, twoColumnFormatting } from '../utils';
 import rehypePrettyCode from 'rehype-pretty-code';
+import { usePrevious } from '../hooks/usePrevious';
+import { messageHandler } from '@estruyf/vscode/dist/client/webview';
+import { WebViewMessages } from '../../constants';
 
 export interface IMarkdownProps {
   content?: string;
@@ -10,7 +13,6 @@ export interface IMarkdownProps {
   updateTheme: (theme: string) => void;
   updateLayout: (layout: string) => void;
   updateBgStyles: (styles: any) => void;
-  updateCustomTheme: (theme: string) => void;
 }
 
 export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
@@ -19,9 +21,11 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
   webviewUrl,
   updateTheme,
   updateLayout,
-  updateBgStyles,
-  updateCustomTheme
+  updateBgStyles
 }: React.PropsWithChildren<IMarkdownProps>) => {
+  const prevContent = usePrevious(content);
+  const [customTheme, setCustomTheme] = React.useState<string | undefined>(undefined);
+
   const {
     markdown,
     setMarkdown,
@@ -44,10 +48,29 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
     }
   });
 
+
+
+  const updateCustomThemePath = React.useCallback((customThemePath: string) => {
+    if (!customThemePath) {
+      setCustomTheme(undefined);
+      return;
+    }
+
+    if (customThemePath.startsWith(`https://`)) {
+      setCustomTheme(customThemePath);
+    } else {
+      messageHandler.request<string>(WebViewMessages.toVscode.parseFileUri, customThemePath).then((customThemeUri) => {
+        setCustomTheme(customThemeUri);
+      }).catch(() => {
+        setCustomTheme(undefined);
+      });
+    }
+  }, []);
+
   React.useEffect(() => {
     updateTheme(matter?.theme || "default");
     updateLayout(matter?.layout || "default");
-    updateCustomTheme(matter?.customTheme || undefined);
+    updateCustomThemePath(matter?.customTheme || undefined);
 
     if (matter?.image) {
       const img = transformImageUrl(webviewUrl || "", matter?.image);
@@ -61,10 +84,10 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
     } else {
       updateBgStyles(undefined);
     }
-  }, [matter, updateTheme, updateLayout, updateCustomTheme]);
+  }, [matter, updateTheme, updateLayout, updateCustomThemePath, updateBgStyles, webviewUrl]);
 
   React.useEffect(() => {
-    if (content) {
+    if (content && content !== prevContent) {
       // Passing the theme here as it could be that the theme has been updated
       setMarkdown(twoColumnFormatting(content), [[rehypePrettyCode, { theme: vsCodeTheme ? vsCodeTheme : {} }]]);
     }
@@ -72,6 +95,8 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
 
   return (
     <>
+      {customTheme && <link href={customTheme} rel="stylesheet" />}
+
       {markdown}
     </>
   );

--- a/src/preview/components/Markdown.tsx
+++ b/src/preview/components/Markdown.tsx
@@ -10,6 +10,7 @@ export interface IMarkdownProps {
   updateTheme: (theme: string) => void;
   updateLayout: (layout: string) => void;
   updateBgStyles: (styles: any) => void;
+  updateCustomTheme: (theme: string) => void;
 }
 
 export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
@@ -18,7 +19,8 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
   webviewUrl,
   updateTheme,
   updateLayout,
-  updateBgStyles
+  updateBgStyles,
+  updateCustomTheme
 }: React.PropsWithChildren<IMarkdownProps>) => {
   const {
     markdown,
@@ -45,6 +47,7 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
   React.useEffect(() => {
     updateTheme(matter?.theme || "default");
     updateLayout(matter?.layout || "default");
+    updateCustomTheme(matter?.customTheme || undefined);
 
     if (matter?.image) {
       const img = transformImageUrl(webviewUrl || "", matter?.image);
@@ -58,7 +61,7 @@ export const Markdown: React.FunctionComponent<IMarkdownProps> = ({
     } else {
       updateBgStyles(undefined);
     }
-  }, [matter, updateTheme, updateLayout]);
+  }, [matter, updateTheme, updateLayout, updateCustomTheme]);
 
   React.useEffect(() => {
     if (content) {

--- a/src/preview/components/MarkdownPreview.tsx
+++ b/src/preview/components/MarkdownPreview.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Messenger } from '@estruyf/vscode/dist/client/webview';
+import { messageHandler, Messenger } from '@estruyf/vscode/dist/client/webview';
 import { SlideLayout, WebViewMessages } from '../../constants';
 import { Markdown } from './Markdown';
 import { EventData } from '@estruyf/vscode';
@@ -21,6 +21,7 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
   const { content, crntFilePath, getFileContents } = useFileContents();
   const [theme, setTheme] = React.useState<string | undefined>(undefined);
   const [layout, setLayout] = React.useState<string | undefined>(undefined);
+  const [customTheme, setCustomTheme] = React.useState<string | undefined>(undefined);
   const [bgStyles, setBgStyles] = React.useState<any | null>(null);
   const [showControls, setShowControls] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
@@ -62,6 +63,24 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     resetCursorTimeout();
   }, [resetCursorTimeout]);
 
+  const updateCustomThemePath = React.useCallback((customThemePath: string) => {
+    if (!customThemePath) {
+      setCustomTheme(undefined);
+      return;
+    }
+
+    if (customThemePath.startsWith(`https://`)) {
+      setCustomTheme(customThemePath);
+    } else {
+      messageHandler.request<string>(WebViewMessages.toVscode.parseFileUri, customThemePath).then((customThemeUri) => {
+        setCustomTheme(customThemeUri);
+        console.log('updateCustomThemePath', customThemeUri);
+      }).catch(() => {
+        setCustomTheme(undefined);
+      });
+    }
+  }, []);
+
   React.useEffect(() => {
     getFileContents(fileUri);
   }, [fileUri]);
@@ -74,55 +93,62 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     };
   }, []);
 
+  console.log('customTheme', customTheme);
+
   return (
-    <div
-      key={crntFilePath}
-      ref={ref}
-      className={`slide fade-in ${theme || "default"} relative w-full h-full overflow-hidden`}
-      onMouseEnter={() => setShowControls(true)}
-      onMouseLeave={() => setShowControls(false)}
-      onMouseMove={handleMouseMove}
-      style={{ cursor: cursorVisible ? 'default' : 'none' }}
-    >
+    <>
+      {customTheme && <link href={customTheme} rel="stylesheet" />}
+
       <div
-        className='slide__container absolute top-[50%] left-[50%] w-[960px] h-[540px]'
-        style={{ transform: 'translate(-50%, -50%) scale(var(--demotime-scale, 1))' }}>
+        key={crntFilePath}
+        ref={ref}
+        className={`slide fade-in ${theme || "default"} relative w-full h-full overflow-hidden`}
+        onMouseEnter={() => setShowControls(true)}
+        onMouseLeave={() => setShowControls(false)}
+        onMouseMove={handleMouseMove}
+        style={{ cursor: cursorVisible ? 'default' : 'none' }}
+      >
         <div
-          ref={slideRef}
-          className={`slide__layout ${slideClasses || ""} ${layout || "default"}`}
-          style={getBgStyles()}>
-          {
-            layout === SlideLayout.ImageLeft && (
-              <div className={`slide__image_left w-full h-full`} style={bgStyles}></div>
-            )
-          }
+          className='slide__container absolute top-[50%] left-[50%] w-[960px] h-[540px]'
+          style={{ transform: 'translate(-50%, -50%) scale(var(--demotime-scale, 1))' }}>
+          <div
+            ref={slideRef}
+            className={`slide__layout ${slideClasses || ""} ${layout || "default"}`}
+            style={getBgStyles()}>
+            {
+              layout === SlideLayout.ImageLeft && (
+                <div className={`slide__image_left w-full h-full`} style={bgStyles}></div>
+              )
+            }
 
-          {
-            content && vsCodeTheme ? (
-              <div className='slide__content'>
-                <div className='slide__content__inner'>
-                  <Markdown
-                    content={content}
-                    vsCodeTheme={vsCodeTheme}
-                    webviewUrl={webviewUrl}
-                    updateTheme={setTheme}
-                    updateLayout={setLayout}
-                    updateBgStyles={setBgStyles}
-                  />
+            {
+              content && vsCodeTheme ? (
+                <div className='slide__content'>
+                  <div className='slide__content__inner'>
+                    <Markdown
+                      content={content}
+                      vsCodeTheme={vsCodeTheme}
+                      webviewUrl={webviewUrl}
+                      updateTheme={setTheme}
+                      updateCustomTheme={(customTheme) => updateCustomThemePath(customTheme)}
+                      updateLayout={setLayout}
+                      updateBgStyles={setBgStyles}
+                    />
+                  </div>
                 </div>
-              </div>
-            ) : null
-          }
+              ) : null
+            }
 
-          {
-            layout === SlideLayout.ImageRight && (
-              <div className={`slide__image_right w-full h-full`} style={bgStyles}></div>
-            )
-          }
+            {
+              layout === SlideLayout.ImageRight && (
+                <div className={`slide__image_right w-full h-full`} style={bgStyles}></div>
+              )
+            }
+          </div>
         </div>
-      </div>
 
-      <SlideControls show={showControls && cursorVisible} path={crntFilePath} />
-    </div>
+        <SlideControls show={showControls && cursorVisible} path={crntFilePath} />
+      </div>
+    </>
   );
 };

--- a/src/preview/components/MarkdownPreview.tsx
+++ b/src/preview/components/MarkdownPreview.tsx
@@ -21,7 +21,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
   const { content, crntFilePath, getFileContents } = useFileContents();
   const [theme, setTheme] = React.useState<string | undefined>(undefined);
   const [layout, setLayout] = React.useState<string | undefined>(undefined);
-  const [customTheme, setCustomTheme] = React.useState<string | undefined>(undefined);
   const [bgStyles, setBgStyles] = React.useState<any | null>(null);
   const [showControls, setShowControls] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
@@ -41,16 +40,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     }
   };
 
-  const slideClasses = React.useMemo(() => {
-    if (!layout) {
-      return '';
-    }
-
-    if (layout === SlideLayout.ImageLeft || layout === SlideLayout.ImageRight) {
-      return 'grid grid-cols-2 w-full h-full auto-rows-fr';
-    }
-  }, [layout]);
-
   const getBgStyles = React.useCallback(() => {
     if (!layout || layout === SlideLayout.ImageLeft || layout === SlideLayout.ImageRight) {
       return undefined;
@@ -62,24 +51,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
   const handleMouseMove = React.useCallback(() => {
     resetCursorTimeout();
   }, [resetCursorTimeout]);
-
-  const updateCustomThemePath = React.useCallback((customThemePath: string) => {
-    if (!customThemePath) {
-      setCustomTheme(undefined);
-      return;
-    }
-
-    if (customThemePath.startsWith(`https://`)) {
-      setCustomTheme(customThemePath);
-    } else {
-      messageHandler.request<string>(WebViewMessages.toVscode.parseFileUri, customThemePath).then((customThemeUri) => {
-        setCustomTheme(customThemeUri);
-        console.log('updateCustomThemePath', customThemeUri);
-      }).catch(() => {
-        setCustomTheme(undefined);
-      });
-    }
-  }, []);
 
   React.useEffect(() => {
     getFileContents(fileUri);
@@ -93,11 +64,8 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     };
   }, []);
 
-  console.log('customTheme', customTheme);
-
   return (
     <>
-      {customTheme && <link href={customTheme} rel="stylesheet" />}
 
       <div
         key={crntFilePath}
@@ -113,7 +81,7 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
           style={{ transform: 'translate(-50%, -50%) scale(var(--demotime-scale, 1))' }}>
           <div
             ref={slideRef}
-            className={`slide__layout ${slideClasses || ""} ${layout || "default"}`}
+            className={`slide__layout ${layout || "default"}`}
             style={getBgStyles()}>
             {
               layout === SlideLayout.ImageLeft && (
@@ -130,7 +98,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
                       vsCodeTheme={vsCodeTheme}
                       webviewUrl={webviewUrl}
                       updateTheme={setTheme}
-                      updateCustomTheme={(customTheme) => updateCustomThemePath(customTheme)}
                       updateLayout={setLayout}
                       updateBgStyles={setBgStyles}
                     />

--- a/src/preview/components/SlideControls.tsx
+++ b/src/preview/components/SlideControls.tsx
@@ -74,7 +74,6 @@ export const SlideControls: React.FunctionComponent<ISlideControlsProps> = ({
 
   React.useEffect(() => {
     messageHandler.request<boolean>(WebViewMessages.toVscode.getPresentationStarted).then((value) => {
-      console.log("value", value);
       setIsPresentationMode(value);
     });
 

--- a/src/preview/hooks/useTheme.tsx
+++ b/src/preview/hooks/useTheme.tsx
@@ -19,7 +19,6 @@ export default function useTheme(options?: any) {
   const getVsCodeTheme = () => {
 
     messageHandler.request<any | null>(WebViewMessages.toVscode.getTheme, getThemeName()).then((theme) => {
-      console.log('getVsCodeTheme', theme);
       if (theme === null) {
         // Check if light or dark theme
         const elm = document.body.getAttribute(`data-vscode-theme-kind`);
@@ -39,8 +38,6 @@ export default function useTheme(options?: any) {
   };
 
   useEffect(() => {
-    console.log('Theme changed', theme);
-    console.log('prevTheme changed', prevTheme);
     if (theme !== prevTheme) {
       getVsCodeTheme();
     }

--- a/src/preview/styles.css
+++ b/src/preview/styles.css
@@ -57,3 +57,9 @@ pre code {
 .fade-in {
   animation: fadeIn 300ms ease-in-out;
 }
+
+/* Layouts */
+.image-left,
+.image-right {
+  @apply grid grid-cols-2 w-full h-full auto-rows-fr;
+}

--- a/src/services/DemoRunner.ts
+++ b/src/services/DemoRunner.ts
@@ -1,6 +1,6 @@
 import { PresenterView } from "./../presenterView/PresenterView";
 import { COMMAND, Config, ContextKeys, StateKeys, WebViewMessages } from "../constants";
-import { Action, Demo, DemoFileCache, Demos, IImagePreview, Step, Subscription } from "../models";
+import { Action, Demo, DemoFileCache, Demos, IImagePreview, ISlidePreview, Step, Subscription } from "../models";
 import { Extension } from "./Extension";
 import {
   Position,
@@ -649,9 +649,15 @@ export class DemoRunner {
         continue;
       }
 
-      if (step.action === Action.ImagePreview || step.action === Action.OpenSlide) {
+      if (step.action === Action.ImagePreview) {
         const { path, theme } = step as IImagePreview;
         Preview.show(path as string, theme);
+        continue;
+      }
+
+      if (step.action === Action.OpenSlide) {
+        const { path } = step as ISlidePreview;
+        Preview.show(path as string);
         continue;
       }
 

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -103,7 +103,7 @@ export class PdfExportService {
           await page.close();
           await context.close();
           await browser.close();
-          // await workspace.fs.delete(tempHtmlOutputPath);
+          await workspace.fs.delete(tempHtmlOutputPath);
           Notifications.info("Slides exported to PDF successfully.");
         }
       );

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -15,7 +15,7 @@ import { FileProvider } from ".";
 import { getTheme, readFile, writeFile } from "../utils";
 import { commands, Uri, workspace, WorkspaceFolder, window, ProgressLocation } from "vscode";
 import { Page } from "playwright-chromium";
-import { General } from "../constants";
+import { COMMAND, General } from "../constants";
 
 export class PdfExportService {
   private static workspaceFolder: WorkspaceFolder | undefined;
@@ -24,7 +24,7 @@ export class PdfExportService {
     const subscriptions: Subscription[] = Extension.getInstance().subscriptions;
     PdfExportService.init();
 
-    subscriptions.push(commands.registerCommand("demo-time.exportToPdf", PdfExportService.exportToPdf));
+    subscriptions.push(commands.registerCommand(COMMAND.exportToPdf, PdfExportService.exportToPdf));
   }
 
   public static init() {

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -102,7 +102,7 @@ export class PdfExportService {
           await page.close();
           await context.close();
           await browser.close();
-          // await workspace.fs.delete(tempHtmlOutputPath);
+          await workspace.fs.delete(tempHtmlOutputPath);
           Notifications.info("Slides exported to PDF successfully.");
         }
       );

--- a/src/services/PdfExportService.ts
+++ b/src/services/PdfExportService.ts
@@ -1,0 +1,261 @@
+import remarkParse from "remark-parse";
+import { SlideTheme } from "../constants/SlideTheme";
+import remarkRehype from "remark-rehype";
+import remarkFrontmatter from "remark-frontmatter";
+import rehypeRaw from "rehype-raw";
+import rehypePrettyCode from "rehype-pretty-code";
+import rehypeStringify from "rehype-stringify";
+import { unified } from "unified";
+import { matter } from "vfile-matter";
+import { resolve } from "mlly";
+import { Notifications } from "./Notifications";
+import { Action, Step, Subscription } from "../models";
+import { Extension } from "./Extension";
+import { FileProvider } from ".";
+import { getTheme, readFile, writeFile } from "../utils";
+import { commands, Uri, workspace, WorkspaceFolder, window, ProgressLocation } from "vscode";
+import { Page } from "playwright-chromium";
+import { General } from "../constants";
+
+export class PdfExportService {
+  private static workspaceFolder: WorkspaceFolder | undefined;
+
+  public static register() {
+    const subscriptions: Subscription[] = Extension.getInstance().subscriptions;
+    PdfExportService.init();
+
+    subscriptions.push(commands.registerCommand("demo-time.exportToPdf", PdfExportService.exportToPdf));
+  }
+
+  public static init() {
+    // Get the workspace folder
+    const workspaceFolder = workspace.workspaceFolders?.[0];
+    if (workspaceFolder) {
+      PdfExportService.workspaceFolder = workspaceFolder;
+    }
+  }
+
+  /**
+   * Export all slides from demo files to a PDF
+   */
+  public static async exportToPdf(): Promise<void> {
+    if (!PdfExportService.workspaceFolder) {
+      Notifications.error("No workspace folder found.");
+      return;
+    }
+
+    try {
+      await window.withProgress(
+        {
+          location: ProgressLocation.Notification,
+          title: "Exporting slides to PDF",
+          cancellable: false,
+        },
+        async (progress) => {
+          const { chromium } = await PdfExportService.getPlaywright();
+          const browser = await chromium.launch();
+          const context = await browser.newContext();
+          const page = await context.newPage();
+
+          // Get all demo files
+          const demoFiles = await FileProvider.getFiles();
+          if (!demoFiles) {
+            Notifications.error("No demo files found.");
+            return;
+          }
+
+          // Get all slide actions
+          const slideActions: Step[] = [];
+          for (const demoFile of Object.values(demoFiles)) {
+            demoFile.demos.forEach((demo) => {
+              demo.steps.forEach((step) => {
+                if (step.action === Action.OpenSlide && step.path) {
+                  slideActions.push(step);
+                }
+              });
+            });
+          }
+
+          // Retrieving slide contents
+          progress.report({ message: "Retrieving slide contents..." });
+          const slideContents = await Promise.all(
+            slideActions.map(async (slideAction) => {
+              const slideUri = Uri.joinPath(PdfExportService.workspaceFolder?.uri as Uri, slideAction.path as string);
+              const content = await readFile(slideUri);
+              return {
+                content: content,
+              };
+            })
+          );
+
+          // Generate HTML for all slides
+          progress.report({ message: "Generating HTML for slides..." });
+          const html = await PdfExportService.generateSlidesHtml(slideContents);
+          const tempHtmlOutputPath = Uri.joinPath(PdfExportService.workspaceFolder?.uri as Uri, General.htmlExportFile);
+          await writeFile(tempHtmlOutputPath, html);
+
+          // Convert HTML to PDF
+          progress.report({ message: "Converting HTML to PDF..." });
+          await PdfExportService.generatePdfFromHtml(page, tempHtmlOutputPath.fsPath);
+
+          // Clean up
+          await page.close();
+          await context.close();
+          await browser.close();
+          // await workspace.fs.delete(tempHtmlOutputPath);
+          Notifications.info("Slides exported to PDF successfully.");
+        }
+      );
+    } catch (error) {
+      Notifications.error(`Error exporting slides to PDF: ${(error as Error).message}`);
+      return;
+    }
+  }
+
+  private static async getPlaywright(): Promise<typeof import("playwright-chromium")> {
+    try {
+      return await import(await resolve("playwright-chromium", { url: PdfExportService.workspaceFolder?.uri.fsPath }));
+    } catch {}
+
+    try {
+      return await import("playwright-chromium");
+    } catch {}
+
+    throw new Error(
+      "Playwright not found. Please install Playwright to export slides to PDF `npm i playwright-chromium -D`."
+    );
+  }
+
+  /**
+   * Generate HTML for slides using the existing markdown processing pipeline
+   */
+  private static async generateSlidesHtml(slides: { content: string }[]): Promise<string> {
+    const theme = await getTheme(undefined);
+
+    // Generate slide content HTML
+    const slideContents = await Promise.all(
+      slides.map(async (slide) => {
+        const processor = unified()
+          .use(remarkParse)
+          .use(remarkRehype, {
+            allowDangerousHtml: true,
+          })
+          .use(rehypeRaw)
+          .use(rehypePrettyCode, { theme: theme ? theme : {} })
+          .use(remarkFrontmatter)
+          .use(rehypeStringify)
+          .use(() => (_, file) => {
+            try {
+              matter(file);
+            } catch (err) {
+              // Catch error and ignore it
+            }
+          });
+
+        try {
+          const vfile = await processor.process(slide.content);
+          const theme = (vfile.data?.matter as any)?.theme || SlideTheme.default;
+          return {
+            html: vfile,
+            theme: theme,
+          };
+        } catch (error) {
+          console.error("Error processing slide content:", (error as Error).message);
+          return;
+        }
+      })
+    );
+
+    const extensionPath = Extension.getInstance().extensionPath;
+    const exportStyles = await readFile(Uri.joinPath(Uri.parse(extensionPath), "assets", "styles", "export.css"));
+    const css = await PdfExportService.updateColorsInCss(exportStyles);
+
+    // Create the HTML document with all slides
+    let html = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demo Time Slides</title>
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <style type="text/tailwindcss">
+  ${css}
+  </style>
+</head>
+<body>
+    `;
+
+    // Add each slide as a div
+    slideContents
+      .filter((slide) => slide !== undefined)
+      .forEach((slide, index) => {
+        if (slide) {
+          html += `<div class="slide ${slide.theme.toLowerCase()}" id="slide-${index + 1}">
+  ${slide.html}
+</div>`;
+        }
+      });
+
+    html += `
+      </body>
+      </html>
+    `;
+
+    return html;
+  }
+
+  private static async generatePdfFromHtml(page: Page, htmlPath: string): Promise<void> {
+    // Load the HTML file
+    await page.goto(`file://${htmlPath}`, { waitUntil: "networkidle" });
+    await page.waitForLoadState("networkidle");
+    await page.emulateMedia({ media: "print" });
+
+    // Generate the PDF
+    const pdfPath = Uri.joinPath(PdfExportService.workspaceFolder?.uri as Uri, General.pdfExportFile).fsPath;
+    await page.pdf({
+      path: pdfPath,
+      width: "960px",
+      height: "540px",
+      printBackground: true,
+      margin: {
+        top: "0",
+        right: "0",
+        bottom: "0",
+        left: "0",
+      },
+      preferCSSPageSize: true,
+    });
+  }
+
+  private static async updateColorsInCss(css: string): Promise<string> {
+    const theme = await getTheme(undefined);
+    if (!theme) {
+      return css;
+    }
+
+    // Get the color variables from the theme
+    const colors = Object.entries(theme.colors).reduce((acc, [key, value]) => {
+      acc[key] = value as string;
+      return acc;
+    }, {} as Record<string, string>);
+
+    // Get the font size and family from the editor settings
+    // --vscode-editor-font-size
+    const editorFontSize = workspace.getConfiguration("editor").get("fontSize") as number;
+    // --vscode-editor-font-family
+    const editorFontFamily = workspace.getConfiguration("editor").get("fontFamily") as string;
+
+    // Add the colors to the top of the CSS
+    let updatedCss = ":root {\n";
+    updatedCss += `  --vscode-editor-font-size: ${editorFontSize}px;\n`;
+    updatedCss += `  --vscode-editor-font-family: ${editorFontFamily};\n`;
+    for (const [key, value] of Object.entries(colors)) {
+      updatedCss += `  --vscode-${key.replace(/\./g, "-")}: ${value};\n`;
+    }
+    updatedCss += "}\n";
+    updatedCss += css;
+
+    return updatedCss;
+  }
+}

--- a/src/services/Slides.ts
+++ b/src/services/Slides.ts
@@ -162,7 +162,7 @@ layout: ${layout.toLowerCase()}
       {
         provideHover(document, position) {
           const text = document.getText();
-          const frontmatterRegex = /^---\s*([\s\S]*?)\s*---/;
+          const frontmatterRegex = /^---(?:[^\r\n]*\r?\n)+?---/;
           const frontmatterMatch = frontmatterRegex.exec(text);
 
           if (frontmatterMatch) {

--- a/src/utils/getRelPath.ts
+++ b/src/utils/getRelPath.ts
@@ -1,0 +1,10 @@
+import { Extension } from "../services";
+
+export const getRelPath = (path: string) => {
+  const workspaceFolder = Extension.getInstance().workspaceFolder;
+  if (!workspaceFolder) {
+    return path;
+  }
+  const relativePath = path.replace(workspaceFolder.uri.path, "");
+  return relativePath.startsWith("/") ? relativePath.slice(1) : relativePath;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,6 +22,7 @@ export * from "./getNextDemoFile";
 export * from "./getPlatform";
 export * from "./getPositionAndRange";
 export * from "./getPreviousDemoFile";
+export * from "./getRelPath";
 export * from "./getShellPath";
 export * from "./getTheme";
 export * from "./getUserInput";


### PR DESCRIPTION
- Optimized package size
- [#63](https://github.com/estruyf/vscode-demo-time/issues/63): Added completion and hover panel support for the frontmatter of the markdown slides
- [#69](https://github.com/estruyf/vscode-demo-time/issues/69): Added the functionality to export the slides to a PDF file
- [#72](https://github.com/estruyf/vscode-demo-time/issues/72): Moved the custom theme property from the demo JSON to the slide's frontmatter