### PR TITLE
feat: endPlaceholder starts looking only after startPlaceholder

### DIFF
--- a/src/utils/findPositionByPlaceholders.ts
+++ b/src/utils/findPositionByPlaceholders.ts
@@ -38,11 +38,15 @@ export const findPositionByPlaceholders = async (
   }
 
   if (endPlaceholder) {
-    endPosition = findPosition(fileTxt, endPlaceholder, true);
+    endPosition = findPosition(fileTxt.substring(startIdx), endPlaceholder, true);
     if (!endPosition) {
       Notifications.error(`End placeholder "${endPlaceholder}" not found in file "${filePath}"`);
       return;
     }
+    endPosition = new Position(
+      endPosition.line + startPosition.line,
+      endPosition.character
+    );
   }
 
   return {


### PR DESCRIPTION
I noticed that endPlaceholder can match even before startPlaceholder leading to an unexpected matching, apparently from the start of the file up to startPlaceholder as the last line matched.

Using
```
          "startPlaceholder": "foo",
          "endPlaceholder": "}"
```
Before
<img width="393" alt="image" src="https://github.com/user-attachments/assets/abbfd601-7db6-4d5f-8643-ac43e017c731" />


After
<img width="416" alt="image" src="https://github.com/user-attachments/assets/42b21d27-ff76-4dce-b436-e8d253ccb4ff" />
