### PR TITLE
Fix: Slide preview remains visible after saving twice

### DIFF
--- a/src/preview/components/MarkdownPreview.tsx
+++ b/src/preview/components/MarkdownPreview.tsx
@@ -32,6 +32,7 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
   const { vsCodeTheme, isDarkTheme } = useTheme();
   const [slides, setSlides] = React.useState<Slide[]>([]);
   const [crntSlide, setCrntSlide] = React.useState<Slide | null>(null);
+  const [refreshKey, setRefreshKey] = React.useState(0);
   const { scale } = useScale(ref, slideRef);
   const { mousePosition, handleMouseMove } = useMousePosition(slideRef, scale, resetCursorTimeout);
 
@@ -47,6 +48,7 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
       messageHandler.send(WebViewMessages.toVscode.hasNextSlide, false);
       messageHandler.send(WebViewMessages.toVscode.hasPreviousSlide, false);
       getFileContents(payload);
+      setRefreshKey(prevKey => prevKey + 1);
     }
   };
 
@@ -96,7 +98,7 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
         messageHandler.send(WebViewMessages.toVscode.hasNextSlide, true);
       }
     }
-  }, [content]);
+  }, [content, refreshKey]);
 
   React.useEffect(() => {
     getFileContents(fileUri);


### PR DESCRIPTION
Addresses issue #115 where the slide preview would become empty if a file was saved twice without any content changes.

The fix introduces a `refreshKey` state variable in `MarkdownPreview.tsx`. This key is updated every time the `triggerUpdate` message is received. The `useEffect` hook responsible for parsing and rendering slides now depends on this `refreshKey` in addition to the file content. This ensures that the slides are re-processed and re-rendered even if the file content itself hasn't changed, resolving the disappearing preview problem.