### PR TITLE
feat: Preserve current slide index on preview refresh

### DIFF
--- a/src/constants/WebViewMessages.ts
+++ b/src/constants/WebViewMessages.ts
@@ -24,6 +24,7 @@ export const WebViewMessages = {
     setHasClickListener: "setHasClickListener",
     hasNextSlide: "hasNextSlide",
     hasPreviousSlide: "hasPreviousSlide",
+    updateSlideIndex: "updateSlideIndex", // New message
   },
   toWebview: {
     updateClock: "updateClock",
@@ -43,5 +44,6 @@ export const WebViewMessages = {
     updateIsInPresentationMode: "updateIsInPresentationMode",
     previousSlide: "previousSlide",
     nextSlide: "nextSlide",
+    setInitialSlide: "setInitialSlide", // New message
   },
 };

--- a/src/constants/WebViewMessages.ts
+++ b/src/constants/WebViewMessages.ts
@@ -44,6 +44,5 @@ export const WebViewMessages = {
     updateIsInPresentationMode: "updateIsInPresentationMode",
     previousSlide: "previousSlide",
     nextSlide: "nextSlide",
-    setInitialSlide: "setInitialSlide", // New message
   },
 };

--- a/src/preview/Preview.ts
+++ b/src/preview/Preview.ts
@@ -14,7 +14,6 @@ export class Preview {
   private static crntFile: string | null = null;
   private static crntCss: string | null = null;
   private static currentSlideIndex: number = 0;
-  private static lastFileProcessed: string | null = null;
 
   public static register() {
     const subscriptions = Extension.getInstance().subscriptions;
@@ -50,13 +49,12 @@ export class Preview {
   }
 
   public static async show(fileUri: string, css?: string) {
-    Preview.crntFile = fileUri ?? null; // fileUri from argument is the source of truth
-    Preview.crntCss = css ?? null;
-
-    if (Preview.crntFile !== Preview.lastFileProcessed) {
+    if (Preview.crntFile !== fileUri) {
       Preview.currentSlideIndex = 0;
-      Preview.lastFileProcessed = Preview.crntFile;
     }
+
+    Preview.crntFile = fileUri ?? null;
+    Preview.crntCss = css ?? null;
 
     if (Preview.isOpen) {
       Preview.reveal();

--- a/src/preview/components/MarkdownPreview.tsx
+++ b/src/preview/components/MarkdownPreview.tsx
@@ -14,12 +14,12 @@ import { SlideParser } from '../../services/SlideParser';
 import { useMousePosition } from '../hooks/useMousePosition';
 
 export interface IMarkdownPreviewProps {
-  // fileUri: string; // No longer needed as prop
+  fileUri: string;
   webviewUrl: string | null;
 }
 
 export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = ({
-  // fileUri, // No longer needed as prop
+  fileUri,
   webviewUrl
 }: React.PropsWithChildren<IMarkdownPreviewProps>) => {
   const { content, crntFilePath, initialSlideIndex, getFileContents } = useFileContents();
@@ -37,8 +37,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
   const { scale } = useScale(ref, slideRef);
   const { mousePosition, handleMouseMove } = useMousePosition(slideRef, scale, resetCursorTimeout);
 
-  // Removed the two useEffect hooks that were listening for WebViewMessages.toWebview.setInitialSlide
-
   React.useEffect(() => {
     if (slides && slides.length > 0 && typeof initialSlideIndex === 'number') {
       if (initialSlideIndex >= 0 && initialSlideIndex < slides.length) {
@@ -55,9 +53,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     // or if slides is undefined (still loading).
     // The logic aims to set slide based on initialSlideIndex once slides are confirmed.
   }, [initialSlideIndex, slides, setCrntSlide]);
-
-  // Removed the old messageListener function and its useEffect, as triggerUpdate for content
-  // and initial slide is now handled by useFileContents.
 
   const updateSlideIdx = React.useCallback((slideIdx: number) => {
     if (slideIdx < 0 || slideIdx >= slides.length) {
@@ -107,9 +102,6 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     }
   }, [content, refreshKey]);
 
-  // Removed: React.useEffect(() => { getFileContents(fileUri); }, [fileUri]);
-  // This initial load is now handled by useFileContents via triggerUpdate.
-
   React.useEffect(() => {
     setTheme(crntSlide?.frontmatter.theme || SlideTheme.default);
     setLayout(crntSlide?.frontmatter.layout || SlideLayout.Default);
@@ -137,7 +129,9 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
     };
   }, [slides, crntSlide]); // Added slides to dependency array for null/empty check
 
-  // Removed the useEffect that registered the old messageListener (the one with the empty dependency array)
+  React.useEffect(() => {
+    getFileContents(fileUri);
+  }, [fileUri]);
 
   return (
     <>

--- a/src/preview/components/MarkdownPreview.tsx
+++ b/src/preview/components/MarkdownPreview.tsx
@@ -37,18 +37,18 @@ export const MarkdownPreview: React.FunctionComponent<IMarkdownPreviewProps> = (
   const { mousePosition, handleMouseMove } = useMousePosition(slideRef, scale, resetCursorTimeout);
 
   React.useEffect(() => {
-    if (slides && slides.length > 0 && typeof initialSlideIndex === 'number') {
-      if (initialSlideIndex >= 0 && initialSlideIndex < slides.length) {
+    // If slides are loaded and initialSlideIndex is a valid number
+    if (Array.isArray(slides) && slides.length > 0) {
+      if (typeof initialSlideIndex === 'number' && initialSlideIndex >= 0 && initialSlideIndex < slides.length) {
         setCrntSlide(slides[initialSlideIndex]);
       } else {
         setCrntSlide(slides[0]);
       }
-    } else if (slides && slides.length === 0) {
-      setCrntSlide(null);
-    } else if (!slides && initialSlideIndex === undefined) {
+    } else {
+      // No slides loaded or slides is empty
       setCrntSlide(null);
     }
-  }, [initialSlideIndex, slides, setCrntSlide]);
+  }, [initialSlideIndex, slides]);
 
   const updateSlideIdx = React.useCallback((slideIdx: number) => {
     if (slideIdx < 0 || slideIdx >= slides.length) {

--- a/src/preview/components/SlideControls.tsx
+++ b/src/preview/components/SlideControls.tsx
@@ -47,6 +47,7 @@ export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISli
     const prevSlide = currentSlide - 1;
     if (prevSlide >= 0) {
       updateSlideIdx(prevSlide);
+      messageHandler.send(WebViewMessages.toVscode.updateSlideIndex, prevSlide);
     } else if (previousEnabled) {
       messageHandler.send(WebViewMessages.toVscode.runCommand, COMMAND.previous);
     }
@@ -61,6 +62,7 @@ export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISli
     const nextSlide = currentSlide + 1;
     if (nextSlide < slides) {
       updateSlideIdx(nextSlide);
+      messageHandler.send(WebViewMessages.toVscode.updateSlideIndex, nextSlide);
     } else {
       messageHandler.send(WebViewMessages.toVscode.runCommand, COMMAND.start);
     }

--- a/src/preview/hooks/useFileContents.tsx
+++ b/src/preview/hooks/useFileContents.tsx
@@ -33,7 +33,7 @@ export const useFileContents = () => {
       if (command === WebViewMessages.toWebview.triggerUpdate) {
         if (payload && typeof payload.fileUriString === 'string' && typeof payload.slideIndex === 'number') {
           setInitialSlideIndex(payload.slideIndex);
-          getFileContents(payload.fileUriString); 
+          getFileContents(payload.fileUriString);
         }
       }
     };
@@ -43,7 +43,7 @@ export const useFileContents = () => {
     return () => {
       Messenger.unlisten(messageListener);
     };
-  }, [getFileContents]); // getFileContents is a dependency
+  }, [getFileContents]);
 
   return { content, crntFilePath, initialSlideIndex, getFileContents };
 };

--- a/src/preview/hooks/useFileContents.tsx
+++ b/src/preview/hooks/useFileContents.tsx
@@ -1,8 +1,12 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { Messenger } from '@estruyf/vscode/dist/client';
+import { EventData } from '@estruyf/vscode';
+import { WebViewMessages } from '../../constants';
 
 export const useFileContents = () => {
   const [content, setContent] = useState<string | undefined>(undefined);
   const [crntFilePath, setCrntFilePath] = useState<string | undefined>(undefined);
+  const [initialSlideIndex, setInitialSlideIndex] = useState<number | undefined>(0);
 
   const getFileContents = useCallback(async (fileUri: string) => {
     if (!fileUri) {
@@ -19,5 +23,27 @@ export const useFileContents = () => {
       });
   }, []);
 
-  return { content, crntFilePath, getFileContents };
+  useEffect(() => {
+    const messageListener = (message: MessageEvent<EventData<any>>) => {
+      const { command, payload } = message.data;
+      if (!command) {
+        return;
+      }
+
+      if (command === WebViewMessages.toWebview.triggerUpdate) {
+        if (payload && typeof payload.fileUriString === 'string' && typeof payload.slideIndex === 'number') {
+          setInitialSlideIndex(payload.slideIndex);
+          getFileContents(payload.fileUriString); 
+        }
+      }
+    };
+
+    Messenger.listen(messageListener);
+
+    return () => {
+      Messenger.unlisten(messageListener);
+    };
+  }, [getFileContents]); // getFileContents is a dependency
+
+  return { content, crntFilePath, initialSlideIndex, getFileContents };
 };


### PR DESCRIPTION
Implements the functionality to keep the current slide index when the slide preview is refreshed, typically after you save the markdown file.

When a markdown file's preview is open and you navigate to a specific slide, if the file is saved (triggering a preview refresh), the preview will now remain on that same slide instead of reverting to the first slide.

This is achieved by:
- Storing the current slide index when it changes in the webview.
- When the preview reloads for the same file, the stored index is sent to the webview.
- The webview then initializes the slide display to the provided index.
- If a different file is opened for preview, the index resets to 0 (the first slide).
- Includes a fallback to the first slide if the stored index is out of bounds (e.g., if the number of slides has decreased).

Addresses issue #117 (#117) regarding maintaining the slide position on save.