### PR TITLE
focus window before reading clipboard in browser instances

### DIFF
--- a/src/utils/getVariables.ts
+++ b/src/utils/getVariables.ts
@@ -1,21 +1,28 @@
-import { Uri, WorkspaceFolder, workspace, env } from "vscode";
-import { General, StateKeys } from "../constants";
 import { parse as jsonParse } from "jsonc-parser";
+import { env, UIKind, Uri, workspace, WorkspaceFolder } from "vscode";
+import { Config, General, StateKeys } from "../constants";
+import { Extension } from "../services/Extension";
 import { Logger } from "../services/Logger";
 import { fileExists } from "./fileExists";
-import { Extension } from "../services/Extension";
 
 export const getVariables = async (workspaceFolder: WorkspaceFolder): Promise<{ [key: string]: any } | undefined> => {
   try {
-    // Set the default variables
+    const ext = Extension.getInstance();
+
+    if (ext.getSetting<boolean>(Config.api.enabled) && env.uiKind === UIKind.Web) {
+      // otherwise clipboard is not readable in the browser
+      // if request is triggered from another window
+      window.focus();
+    }
     const clipboard = await env.clipboard.readText();
+    // Set the default variables
     const defaultVariables: { [key: string]: string } = {
-      DT_CLIPBOARD: clipboard,
       DT_INPUT: "",
+      DT_CLIPBOARD: clipboard
     };
 
     // Get the state variables
-    const ext = Extension.getInstance();
+
     const stateVariables = ext.getState<{ [key: string]: string }>(StateKeys.variables) || {};
     for (const key of Object.keys(stateVariables)) {
       defaultVariables[key] = stateVariables[key];


### PR DESCRIPTION
## Description

When making an api request to an instance thats running in vscode server, the window needs focus to be able to read from the clipboard.

If and only if api is enabled and uiKInd is detecetd as web the code requests focus for the window before reading the clipboard.

Fixes #136


## Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x ] My code follows the project coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated tests as needed
- [ ] All tests pass locally
- [x] My changes generate no new warnings
- [x] I have linked relevant issues (if applicable)

