### PR TITLE
Fix slide metadata parsing and remove duplicate hover check

### DIFF
--- a/src/services/SlideParser.ts
+++ b/src/services/SlideParser.ts
@@ -176,6 +176,9 @@ export class SlideParser {
       if (slide.docFrontMatter.customTheme) {
         slide.frontmatter.customTheme = slide.docFrontMatter.customTheme;
       }
+      if (slide.docFrontMatter.customLayout) {
+        slide.frontmatter.customLayout = slide.docFrontMatter.customLayout;
+      }
       if (slide.docFrontMatter.transition && !slide.frontmatter.transition) {
         slide.frontmatter.transition = slide.docFrontMatter.transition;
       }
@@ -189,7 +192,7 @@ export class SlideParser {
 
       for (const [key, value] of Object.entries(slide.docFrontMatter)) {
         if (
-          !['theme', 'customTheme', 'transition', 'header', 'footer', 'layout'].includes(key) &&
+          !['theme', 'customTheme', 'customLayout', 'transition', 'header', 'footer', 'layout'].includes(key) &&
           slide.frontmatter[key] === undefined
         ) {
           slide.frontmatter[key] = value;

--- a/src/services/Slides.ts
+++ b/src/services/Slides.ts
@@ -196,10 +196,6 @@ layout: ${layout.toLowerCase()}
                 return new Hover(
                   "Specifies the image URL or path for the slide. Provide a relative path to the image file."
                 );
-              } else if (line.startsWith("customTheme:")) {
-                return new Hover(
-                  "Specifies a custom theme for the slide. Provide a relative path or URL to a CSS file."
-                );
               } else if (line.startsWith("customLayout:")) {
                 return new Hover(
                   "Specifies a custom layout for the slide. Provide a relative path to the Handlebars template."


### PR DESCRIPTION
## Summary
- handle `customLayout` from document frontmatter when parsing slides
- remove duplicate `customTheme` hover info

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68428b8bd288832da7e5b0bbcb3441de