### PR TITLE
Add util tests

### DIFF
--- a/tests/getLineAndCharacterPosition.test.ts
+++ b/tests/getLineAndCharacterPosition.test.ts
@@ -1,0 +1,16 @@
+import { getLineAndCharacterPosition } from '../src/utils/getLineAndCharacterPosition';
+import { describe, it, expect } from '@jest/globals';
+
+describe('getLineAndCharacterPosition', () => {
+  it('parses line and character', () => {
+    expect(getLineAndCharacterPosition('3,5')).toEqual({ line: 2, character: 4 });
+  });
+
+  it('parses line only', () => {
+    expect(getLineAndCharacterPosition('2')).toEqual({ line: 1, character: 0 });
+  });
+
+  it('handles character starting at one', () => {
+    expect(getLineAndCharacterPosition('1,1')).toEqual({ line: 0, character: 0 });
+  });
+});

--- a/tests/getLineInsertionSpeed.test.ts
+++ b/tests/getLineInsertionSpeed.test.ts
@@ -1,0 +1,35 @@
+import { getLineInsertionSpeed } from '../src/utils/getLineInsertionSpeed';
+import { Extension } from '../src/services/Extension';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('vscode', () => ({
+  workspace: { getConfiguration: jest.fn() }
+}), { virtual: true });
+
+jest.mock('../src/services/Extension');
+
+const getInstanceMock = Extension.getInstance as jest.Mock;
+
+describe('getLineInsertionSpeed', () => {
+  beforeEach(() => {
+    getInstanceMock.mockReturnValue({ getSetting: jest.fn() });
+  });
+
+  it('returns setting value when defined', () => {
+    const getSetting = jest.fn().mockReturnValue(50);
+    getInstanceMock.mockReturnValue({ getSetting });
+    expect(getLineInsertionSpeed()).toBe(50);
+  });
+
+  it('overrides with action delay', () => {
+    const getSetting = jest.fn().mockReturnValue(30);
+    getInstanceMock.mockReturnValue({ getSetting });
+    expect(getLineInsertionSpeed(100)).toBe(100);
+  });
+
+  it('defaults to 25 when not set', () => {
+    const getSetting = jest.fn().mockReturnValue(undefined);
+    getInstanceMock.mockReturnValue({ getSetting });
+    expect(getLineInsertionSpeed()).toBe(25);
+  });
+});

--- a/tests/getPlatform.test.ts
+++ b/tests/getPlatform.test.ts
@@ -1,0 +1,22 @@
+import { getPlatform } from '../src/utils/getPlatform';
+import * as os from 'os';
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('os');
+
+describe('getPlatform', () => {
+  it('returns windows for win32', () => {
+    (os.platform as jest.Mock).mockReturnValue('win32');
+    expect(getPlatform()).toBe('windows');
+  });
+
+  it('returns osx for darwin', () => {
+    (os.platform as jest.Mock).mockReturnValue('darwin');
+    expect(getPlatform()).toBe('osx');
+  });
+
+  it('returns linux for others', () => {
+    (os.platform as jest.Mock).mockReturnValue('linux');
+    expect(getPlatform()).toBe('linux');
+  });
+});

--- a/tests/htmlDecode.test.ts
+++ b/tests/htmlDecode.test.ts
@@ -1,0 +1,32 @@
+import { htmlDecode } from '../src/utils/htmlDecode';
+import { decode } from 'entities';
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+
+beforeAll(() => {
+  (global as any).document = {
+    createElement: () => {
+      return {
+        _html: '',
+        childNodes: [] as any[],
+        set innerHTML(value: string) {
+          this._html = value;
+          this.childNodes = [{ textContent: decode(value) }];
+        },
+      };
+    },
+  };
+});
+
+afterAll(() => {
+  delete (global as any).document;
+});
+
+describe('htmlDecode', () => {
+  it('decodes basic HTML entities', () => {
+    expect(htmlDecode('&amp;')).toBe('&');
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(htmlDecode('')).toBeUndefined();
+  });
+});

--- a/tests/lowercaseFirstLetter.test.ts
+++ b/tests/lowercaseFirstLetter.test.ts
@@ -1,0 +1,8 @@
+import { lowercaseFirstLetter } from '../src/utils/lowercaseFirstLetter';
+import { describe, it, expect } from '@jest/globals';
+
+describe('lowercaseFirstLetter', () => {
+  it('lowercases the first character', () => {
+    expect(lowercaseFirstLetter('Hello')).toBe('hello');
+  });
+});

--- a/tests/parseWinPath.test.ts
+++ b/tests/parseWinPath.test.ts
@@ -1,0 +1,12 @@
+import { parseWinPath } from '../src/utils/parseWinPath';
+import { describe, it, expect } from '@jest/globals';
+
+describe('parseWinPath', () => {
+  it('converts backslashes to forward slashes', () => {
+    expect(parseWinPath('folder\\sub\\file.txt')).toBe('folder/sub/file.txt');
+  });
+
+  it('returns empty string when path is undefined', () => {
+    expect(parseWinPath(undefined)).toBe('');
+  });
+});

--- a/tests/removeDemoDuplicates.test.ts
+++ b/tests/removeDemoDuplicates.test.ts
@@ -1,0 +1,19 @@
+import { removeDemoDuplicates } from '../src/utils/removeDemoDuplicates';
+import { describe, it, expect } from '@jest/globals';
+
+describe('removeDemoDuplicates', () => {
+  it('removes items with duplicate idx values', () => {
+    const demos = [
+      { idx: 1, title: 'a' },
+      { idx: 1, title: 'duplicate' },
+      { idx: 2, title: 'b' },
+      { idx: 3, title: 'c' },
+      { idx: 3, title: 'dup' },
+    ];
+    expect(removeDemoDuplicates(demos)).toEqual([
+      { idx: 1, title: 'a' },
+      { idx: 2, title: 'b' },
+      { idx: 3, title: 'c' },
+    ]);
+  });
+});

--- a/tests/sanitizeFileName.test.ts
+++ b/tests/sanitizeFileName.test.ts
@@ -1,0 +1,12 @@
+import { sanitizeFileName } from '../src/utils/sanitizeFileName';
+import { describe, it, expect } from '@jest/globals';
+
+describe('sanitizeFileName', () => {
+  it('adds extension, replaces spaces and lowercases', () => {
+    expect(sanitizeFileName('My File')).toBe('my-file.json');
+  });
+
+  it('does not duplicate extension', () => {
+    expect(sanitizeFileName('demo.json')).toBe('demo.json');
+  });
+});

--- a/tests/sleep.test.ts
+++ b/tests/sleep.test.ts
@@ -1,0 +1,12 @@
+import { sleep } from '../src/utils/sleep';
+import { describe, it, expect, jest } from '@jest/globals';
+
+describe('sleep', () => {
+  it('resolves after the specified delay', async () => {
+    jest.useFakeTimers();
+    const promise = sleep(1000);
+    jest.advanceTimersByTime(1000);
+    await expect(promise).resolves.toBeUndefined();
+    jest.useRealTimers();
+  });
+});

--- a/tests/sortFiles.test.ts
+++ b/tests/sortFiles.test.ts
@@ -1,0 +1,13 @@
+import { sortFiles } from '../src/utils/sortFiles';
+import { describe, it, expect } from '@jest/globals';
+
+describe('sortFiles', () => {
+  it('sorts file names case-insensitively and numerically', () => {
+    const files = {
+      'file10.ts': {} as any,
+      'File2.ts': {} as any,
+      'file1.ts': {} as any,
+    };
+    expect(sortFiles(files)).toEqual(['file1.ts', 'File2.ts', 'file10.ts']);
+  });
+});

--- a/tests/upperCaseFirstLetter.test.ts
+++ b/tests/upperCaseFirstLetter.test.ts
@@ -1,0 +1,8 @@
+import { upperCaseFirstLetter } from '../src/utils/upperCaseFirstLetter';
+import { describe, it, expect } from '@jest/globals';
+
+describe('upperCaseFirstLetter', () => {
+  it('uppercases the first character', () => {
+    expect(upperCaseFirstLetter('world')).toBe('World');
+  });
+});


### PR DESCRIPTION
## Summary
- split grouped util tests so each helper has a dedicated file
- keep original assertions for path, filename and string helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842a721e850832d94338576a1bdedb6