### PR TITLE
Use path.relative for workspace paths

### DIFF
--- a/src/utils/getRelPath.ts
+++ b/src/utils/getRelPath.ts
@@ -1,10 +1,16 @@
-import { Extension } from "../services";
+import path from "node:path";
+import { Extension } from "../services/Extension";
+import { parseWinPath } from "./parseWinPath";
 
-export const getRelPath = (path: string) => {
+export const getRelPath = (fsPath: string) => {
   const workspaceFolder = Extension.getInstance().workspaceFolder;
   if (!workspaceFolder) {
-    return path;
+    return fsPath;
   }
-  const relativePath = path.replace(workspaceFolder.uri.path, "");
-  return relativePath.startsWith("/") ? relativePath.slice(1) : relativePath;
+
+  const from = parseWinPath(workspaceFolder.uri.fsPath);
+  const to = parseWinPath(fsPath);
+
+  const relative = path.posix.relative(from, to);
+  return relative;
 };

--- a/tests/getRelPath.test.ts
+++ b/tests/getRelPath.test.ts
@@ -1,0 +1,35 @@
+import { getRelPath } from '../src/utils/getRelPath';
+import { Extension } from '../src/services/Extension';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('vscode', () => ({}), { virtual: true });
+
+jest.mock('../src/services/Extension');
+
+const getInstanceMock = Extension.getInstance as jest.Mock;
+
+describe('getRelPath', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns path relative to workspace folder', () => {
+    const workspaceFolder = { uri: { fsPath: '/workspace/project' } };
+    getInstanceMock.mockReturnValue({ workspaceFolder });
+
+    expect(getRelPath('/workspace/project/src/file.ts')).toBe('src/file.ts');
+  });
+
+  it('handles Windows style paths', () => {
+    const workspaceFolder = { uri: { fsPath: 'C:\\ws\\project' } };
+    getInstanceMock.mockReturnValue({ workspaceFolder });
+
+    expect(getRelPath('C:\\ws\\project\\src\\file.ts')).toBe('src/file.ts');
+  });
+
+  it('returns original path when workspace folder is missing', () => {
+    getInstanceMock.mockReturnValue({ workspaceFolder: null });
+
+    expect(getRelPath('/workspace/project/src/file.ts')).toBe('/workspace/project/src/file.ts');
+  });
+});


### PR DESCRIPTION
## Summary
- compute relative paths using `path.relative`
- adjust imports to avoid side effects
- test `getRelPath` on Unix and Windows-style paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685185e99da8832d866f615544698cb7