### PR TITLE
Use YAML.stringify for slide frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,8 @@
         "webpack": "^5.97.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.0",
-        "webpack-manifest-plugin": "^5.0.1"
+        "webpack-manifest-plugin": "^5.0.1",
+        "yaml": "^2.8.0"
       },
       "engines": {
         "vscode": "^1.84.0"

--- a/package.json
+++ b/package.json
@@ -663,8 +663,8 @@
     "@estruyf/vscode": "^1.1.0",
     "@types/cors": "^2.8.17",
     "@types/diff": "^7.0.1",
-    "@types/js-yaml": "^4.0.9",
     "@types/jest": "^29.5.11",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "18.x",
     "@types/react": "^18.3.16",
     "@types/react-dom": "^18.3.5",
@@ -680,12 +680,11 @@
     "express": "^4.21.2",
     "glob": "^10.3.10",
     "handlebars": "^4.7.8",
+    "jest": "^29.7.0",
     "js-yaml": "^4.1.0",
     "jsonc-parser": "^3.3.1",
     "mermaid": "^11.6.0",
     "mlly": "^1.7.4",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.1.1",
     "npm-run-all": "^4.1.5",
     "playwright-chromium": "^1.51.1",
     "postcss": "^8.4.49",
@@ -701,6 +700,7 @@
     "remark-rehype": "^11.1.1",
     "style-loader": "^4.0.0",
     "tailwindcss": "^3.4.16",
+    "ts-jest": "^29.1.1",
     "ts-loader": "^9.5.1",
     "tsup": "^8.0.1",
     "typescript": "^5.2.2",
@@ -710,6 +710,7 @@
     "webpack": "^5.97.1",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.0",
-    "webpack-manifest-plugin": "^5.0.1"
+    "webpack-manifest-plugin": "^5.0.1",
+    "yaml": "^2.8.0"
   }
 }

--- a/src/services/SlideParser.ts
+++ b/src/services/SlideParser.ts
@@ -1,6 +1,7 @@
 import { FrontMatterParser } from './FrontMatterParser';
 import { ParserOptions, Slide, InternalSlide, SlideMetadata } from '../models';
 import { SlideLayout } from '../constants';
+import YAML from 'yaml';
 
 export class SlideParser {
   private defaultOptions: Required<ParserOptions> = {
@@ -242,9 +243,7 @@ export class SlideParser {
         // Convert frontmatter to YAML string
         let frontmatterStr = '';
         if (Object.keys(slide.frontmatter).length > 0) {
-          frontmatterStr = `---\n${Object.entries(slide.frontmatter)
-            .map(([key, value]) => `${key}: ${value}`)
-            .join('\n')}\n---\n\n`;
+          frontmatterStr = `---\n${YAML.stringify(slide.frontmatter)}---\n\n`;
         }
 
         // Add slide delimiter if not the first slide

--- a/tests/slideParserMarkdown.test.ts
+++ b/tests/slideParserMarkdown.test.ts
@@ -1,0 +1,57 @@
+import { SlideParser } from '../src/services/SlideParser';
+import { Slide } from '../src/models';
+import YAML from 'yaml';
+import { describe, it, expect } from '@jest/globals';
+
+describe('SlideParser.slidesToMarkdown', () => {
+  it('escapes values containing colons', () => {
+    const parser = new SlideParser();
+    const slides: Slide[] = [
+      {
+        content: 'content',
+        rawContent: 'content',
+        frontmatter: { title: 'foo: bar' },
+        index: 0,
+      },
+    ];
+
+    const md = parser.slidesToMarkdown(slides);
+    const fm = md.split('---\n')[1].split('\n---')[0];
+    const parsed = YAML.parse(fm);
+    expect(parsed.title).toBe('foo: bar');
+  });
+
+  it('handles quotes in values', () => {
+    const parser = new SlideParser();
+    const slides: Slide[] = [
+      {
+        content: 'content',
+        rawContent: 'content',
+        frontmatter: { quote: 'He said "hi"' },
+        index: 0,
+      },
+    ];
+
+    const md = parser.slidesToMarkdown(slides);
+    const fm = md.split('---\n')[1].split('\n---')[0];
+    const parsed = YAML.parse(fm);
+    expect(parsed.quote).toBe('He said "hi"');
+  });
+
+  it('supports multi-line strings', () => {
+    const parser = new SlideParser();
+    const slides: Slide[] = [
+      {
+        content: 'content',
+        rawContent: 'content',
+        frontmatter: { text: 'line1\nline2' },
+        index: 0,
+      },
+    ];
+
+    const md = parser.slidesToMarkdown(slides);
+    const fm = md.split('---\n')[1].split('\n---')[0];
+    const parsed = YAML.parse(fm);
+    expect(parsed.text).toBe('line1\nline2');
+  });
+});


### PR DESCRIPTION
## Summary
- update SlideParser to convert frontmatter using `YAML.stringify`
- add `yaml` dependency
- test SlideParser markdown output with colon, quote and multi-line values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685185d999ac832da119163ee2d9ba92