### PR TITLE
feat: add waitTimeout option to executeTerminalCommand

### DIFF
--- a/apps/vscode-extension/src/services/TerminalService.ts
+++ b/apps/vscode-extension/src/services/TerminalService.ts
@@ -52,7 +52,7 @@ export class TerminalService {
    * @returns A promise that resolves when the command execution is complete.
    */
   public static async executeCommand(step: Step): Promise<void> {
-    let { command, terminalId, autoExecute, insertTypingMode, insertTypingSpeed } = step;
+    let { command, terminalId, autoExecute, insertTypingMode, insertTypingSpeed, waitTimeout } = step;
 
     if (!command) {
       Notifications.error('No command specified');
@@ -79,7 +79,7 @@ export class TerminalService {
         // to handle unreliable 633 sequence ordering (VS Code 1.98+)
         if (terminal.shellIntegration) {
           await Promise.all([
-            TerminalService.waitForTerminalExecuted(command, resolvedTerminalId),
+            TerminalService.waitForTerminalExecuted(command, resolvedTerminalId, waitTimeout),
             sleep(TerminalService.minSafetyDelayMs),
           ]);
         } else {
@@ -100,7 +100,7 @@ export class TerminalService {
     if (execution && typeMode === 'instant') {
       // Dual-layer waiting for shell integration reliability
       await Promise.all([
-        TerminalService.waitForTerminalExecuted(command, resolvedTerminalId),
+        TerminalService.waitForTerminalExecuted(command, resolvedTerminalId, waitTimeout),
         sleep(TerminalService.minSafetyDelayMs),
       ]);
     }
@@ -238,12 +238,13 @@ export class TerminalService {
    *
    * @param command - The exact command string to wait for.
    * @param terminalId - The identifier of the terminal whose last executed command will be observed.
-   * @returns A Promise that resolves when the command is observed or when the 5 second timeout elapses.
+   * @param maxWaitTimeMs - Maximum milliseconds to wait before resolving. Defaults to 5000ms.
+   * @returns A Promise that resolves when the command is observed or when the timeout elapses.
    */
-  private static async waitForTerminalExecuted(command: string, terminalId: string): Promise<void> {
+  private static async waitForTerminalExecuted(command: string, terminalId: string, maxWaitTimeMs?: number): Promise<void> {
     return new Promise<void>((resolve) => {
       const startTime = Date.now();
-      const maxWaitTime = 5000; // 5 seconds
+      const maxWaitTime = maxWaitTimeMs ?? 5000; // Default: 5 seconds
 
       const checkExecution = () => {
         if (TerminalService.lastExecution[terminalId] === command) {

--- a/docs/public/demo-time.schema.json
+++ b/docs/public/demo-time.schema.json
@@ -601,6 +601,9 @@
                       },
                       "insertTypingSpeed": {
                         "$ref": "#/definitions/insertTypingSpeed"
+                      },
+                      "waitTimeout": {
+                        "$ref": "#/definitions/waitTimeout"
                       }
                     }
                   }
@@ -1293,6 +1296,11 @@
     "timeout": {
       "type": "number",
       "title": "Timeout in milliseconds"
+    },
+    "waitTimeout": {
+      "type": "number",
+      "default": 5000,
+      "title": "Maximum time in milliseconds to wait for shell integration to confirm command completion. Overrides the default 5000ms cap. Useful for long-running commands such as builds or test suites."
     },
     "url": {
       "type": "string",

--- a/docs/public/demo-time.schema.json
+++ b/docs/public/demo-time.schema.json
@@ -1300,6 +1300,7 @@
     "waitTimeout": {
       "type": "number",
       "default": 5000,
+      "minimum": 1,
       "title": "Maximum time in milliseconds to wait for shell integration to confirm command completion. Overrides the default 5000ms cap. Useful for long-running commands such as builds or test suites."
     },
     "url": {

--- a/packages/common/src/models/Demos.ts
+++ b/packages/common/src/models/Demos.ts
@@ -135,6 +135,12 @@ export interface Step extends IOpenWebsite, IImagePreview, ITerminal {
 
 export interface ITerminal {
   autoExecute?: boolean;
+  /**
+   * Maximum time in milliseconds to wait for shell integration to confirm
+   * command completion. Overrides the default 5000ms cap. Useful for
+   * long-running commands such as builds or test suites.
+   */
+  waitTimeout?: number;
 }
 
 export interface IOpenWebsite {


### PR DESCRIPTION
Closes #400

Adds an optional `waitTimeout` parameter to `executeTerminalCommand` steps that lets users override the default 5-second shell-integration wait cap.

**Usage:**
```json
{
  "command": "cargo build",
  "waitTimeout": 30000
}
```

Defaults to 5000ms so all existing demos are unaffected.

**Changes:**
- `packages/common/src/models/Demos.ts` — added `waitTimeout?: number` to `ITerminal` interface (which `Step` extends)
- `apps/vscode-extension/src/services/TerminalService.ts` — destructure `waitTimeout` from the step and forward it to `waitForTerminalExecuted`; `waitForTerminalExecuted` now accepts an optional `maxWaitTimeMs` parameter (defaults to 5000)
- `docs/public/demo-time.schema.json` — added `waitTimeout` property to the `executeTerminalCommand` action block and a corresponding definition entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal command execution now supports a per-step timeout setting so users can control how long the app waits for shell integration to confirm command completion (default 5000 ms).
* **Documentation**
  * Demo schema and configuration docs updated to expose the new timeout option and its validation (minimum 1 ms).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/estruyf/vscode-demo-time/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `waitTimeout` option to `TerminalService.executeCommand` for shell integration
> - Adds an optional `waitTimeout` field to the `ITerminal` interface and the terminal step JSON schema, allowing per-step override of the shell integration confirmation timeout.
> - `TerminalService.waitForTerminalExecuted` now accepts an optional `maxWaitTimeMs` parameter, defaulting to the previous hardcoded 5000ms when omitted.
> - Behavioral Change: commands using shell integration will now wait up to `waitTimeout` ms (instead of always 5000ms) before proceeding; commands without a `waitTimeout` set are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd022d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->