### PR TITLE
feat: redesign slide controls into a compact pill bar (#409)

### DIFF
--- a/apps/webviews/src/components/preview/SlideControl.tsx
+++ b/apps/webviews/src/components/preview/SlideControl.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Icon } from 'vscrui';
+import { cn } from '../../utils/cn';
 
 export interface ISlideControlProps {
   action: () => void;
@@ -7,29 +8,79 @@ export interface ISlideControlProps {
   icon?: React.ReactNode;
   title: string;
   disabled?: boolean;
+  /** Renders the larger, full-opacity navigation styling (previous/next). */
   isSlideControl?: boolean;
+  /** Highlights the control with the accent color to indicate an active/toggled state. */
+  active?: boolean;
   className?: string;
+  /** Reflects the pressed state of a toggle button to assistive technologies. */
+  ariaPressed?: boolean;
+  ariaHasPopup?: boolean | 'menu' | 'dialog' | 'listbox' | 'tree' | 'grid';
+  ariaExpanded?: boolean;
+  ariaControls?: string;
+  id?: string;
+  tabIndex?: number;
 }
 
-export const SlideControl: React.FunctionComponent<ISlideControlProps> = ({
-  action,
-  iconName,
-  icon,
-  title,
-  disabled,
-  isSlideControl,
-  className,
-}: React.PropsWithChildren<ISlideControlProps>) => {
-  return (
-    <button
-      title={title}
-      onClick={action}
-      disabled={disabled}
-      className={`p-2 inline-flex justify-center items-center rounded-xs disabled:opacity-50 disabled:cursor-not-allowed ${!isSlideControl ? ' opacity-70 hover:opacity-100' : ''} ${className ? className : "hover:bg-(--vscode-toolbar-hoverBackground)"}`}
-    >
-      <span className="sr-only">{title}</span>
-      {iconName && <Icon name={iconName as never} className="text-(--vscode-editorWidget-foreground)! inline-flex justify-center items-center" />}
-      {icon}
-    </button>
-  );
-};
+export const SlideControl = React.forwardRef<HTMLButtonElement, ISlideControlProps>(
+  (
+    {
+      action,
+      iconName,
+      icon,
+      title,
+      disabled,
+      isSlideControl,
+      active,
+      className,
+      ariaPressed,
+      ariaHasPopup,
+      ariaExpanded,
+      ariaControls,
+      id,
+      tabIndex,
+    },
+    ref,
+  ) => {
+    // The codicon font sets its own `color`, so the accent has to be applied with `!` to win.
+    const codiconColor = active
+      ? 'text-(--color-demo-time-accent)!'
+      : 'text-(--vscode-editorWidget-foreground)!';
+    // SVG icons inherit `currentColor`, so a regular text color on the wrapper is enough.
+    const svgColor = active ? 'text-(--color-demo-time-accent)' : 'text-(--vscode-editorWidget-foreground)';
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        id={id}
+        title={title}
+        aria-label={title}
+        aria-pressed={ariaPressed}
+        aria-haspopup={ariaHasPopup}
+        aria-expanded={ariaExpanded}
+        aria-controls={ariaControls}
+        tabIndex={tabIndex}
+        onClick={action}
+        disabled={disabled}
+        className={cn(
+          'inline-flex justify-center items-center rounded-lg p-2 transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--vscode-focusBorder)',
+          'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent',
+          active
+            ? 'bg-(--color-demo-time-accent-low) hover:bg-(--color-demo-time-accent-low)'
+            : 'hover:bg-(--vscode-toolbar-hoverBackground)',
+          !isSlideControl && !active ? 'opacity-80 hover:opacity-100' : '',
+          className,
+        )}
+      >
+        {iconName && (
+          <Icon name={iconName as never} className={cn(codiconColor, 'inline-flex justify-center items-center')} />
+        )}
+        {icon && <span className={cn(svgColor, 'inline-flex justify-center items-center')}>{icon}</span>}
+      </button>
+    );
+  },
+);
+
+SlideControl.displayName = 'SlideControl';

--- a/apps/webviews/src/components/preview/SlideControls.tsx
+++ b/apps/webviews/src/components/preview/SlideControls.tsx
@@ -3,11 +3,12 @@ import * as React from 'react';
 import { COMMAND, Slide, SlideMetadata } from '@demotime/common';
 import { SlideControl } from './SlideControl';
 import { WhiteboardIcon } from './WhiteboardIcon';
-import { Icon } from 'vscrui';
 import { ProjectorIcon } from './ProjectorIcon';
 import { EventData } from '@estruyf/vscode';
 import { WebViewMessages } from '@demotime/common';
 import { SlideNavigator, SlideOption } from './SlideNavigator';
+import { SlideControlsMenu, ISlideMenuGroup, ISlideMenuItem } from './SlideControlsMenu';
+import { cn } from '../../utils/cn';
 
 export interface ISlideControlsProps {
   show: boolean;
@@ -32,6 +33,13 @@ export interface ISlideControlsProps {
   style?: React.CSSProperties;
   matter?: SlideMetadata;
 }
+
+const Divider: React.FunctionComponent = () => (
+  <div
+    aria-hidden="true"
+    className="w-px self-stretch my-1 bg-(--vscode-editorWidget-foreground) opacity-20"
+  />
+);
 
 export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISlideControlsProps>> = ({
   show,
@@ -61,6 +69,7 @@ export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISli
   const [isPresentationMode, setIsPresentationMode] = React.useState(false);
   const [showPosition, setShowPosition] = React.useState(false);
   const [isNavigatorOpen, setIsNavigatorOpen] = React.useState(false);
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const [extensionAutoProceedManaged, setExtensionAutoProceedManaged] = React.useState(false);
 
 
@@ -110,6 +119,20 @@ export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISli
     messageHandler.send(WebViewMessages.toVscode.openFile, path);
   }, [path]);
 
+  const toggleMousePosition = React.useCallback(() => {
+    const nextValue = !showPosition;
+    setShowPosition(nextValue);
+    triggerMouseMove(nextValue);
+  }, [showPosition, triggerMouseMove]);
+
+  const toggleLaserPointer = React.useCallback(() => {
+    onLaserPointerToggle?.(!laserPointerEnabled);
+  }, [laserPointerEnabled, onLaserPointerToggle]);
+
+  const toggleZoom = React.useCallback(() => {
+    onZoomToggle?.();
+  }, [onZoomToggle]);
+
   React.useEffect(() => {
     // Always clear previous timer on effect run
     let timer: NodeJS.Timeout | undefined;
@@ -145,45 +168,106 @@ export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISli
     };
   }, []);
 
+  const hasMultipleSlides = slides > 1;
+  const canPrevious = previousEnabled || (hasMultipleSlides && currentSlide >= 1);
+  const showPrevious = hasMultipleSlides || previousEnabled;
+  const hasNavigator = hasMultipleSlides && !!slideOptions && slideOptions.length > 0;
+
+  // Secondary actions live in the overflow menu so the bar stays compact and discoverable.
+  const menuGroups = React.useMemo<ISlideMenuGroup[]>(() => {
+    const groups: ISlideMenuGroup[] = [];
+
+    const slideItems: ISlideMenuItem[] = [];
+    if (!isPresentationMode) {
+      slideItems.push({
+        id: 'mouse-position',
+        label: 'Mouse position',
+        iconName: 'symbol-ruler',
+        pressed: showPosition,
+        onSelect: toggleMousePosition,
+      });
+      if (path) {
+        slideItems.push({
+          id: 'open-slide-source',
+          label: 'Open slide source',
+          iconName: 'file-code',
+          onSelect: openSlideSource,
+        });
+      }
+    }
+    if (slideItems.length > 0) {
+      groups.push({ id: 'slide', label: 'Slide', items: slideItems });
+    }
+
+    groups.push({
+      id: 'workspace',
+      label: 'Workspace',
+      items: [
+        { id: 'show-demos', label: 'Show demos', iconName: 'list-unordered', onSelect: focusPanel },
+        { id: 'close-sidebar', label: 'Close sidebar', iconName: 'layout-sidebar-left', onSelect: closeSidebar },
+      ],
+    });
+
+    groups.push({
+      id: 'view',
+      items: [{ id: 'hide-controls', label: 'Hide controls', iconName: 'eye-closed', onSelect: hideControls }],
+    });
+
+    return groups;
+  }, [isPresentationMode, showPosition, path, toggleMousePosition, openSlideSource, focusPanel, closeSidebar, hideControls]);
+
+  const isOverlayOpen = isNavigatorOpen || isMenuOpen;
+  const visible = show || isOverlayOpen;
+
   return (
     <div
-      className={`absolute bottom-0 w-full transition-opacity duration-300 ${isNavigatorOpen ? 'opacity-100' : show ? 'opacity-90' : 'opacity-0 pointer-events-none'
-        }`}
+      className={cn(
+        'absolute bottom-0 left-0 w-full flex justify-center px-4 pb-4 pointer-events-none transition-opacity duration-300',
+        visible ? 'opacity-100' : 'opacity-0',
+      )}
       style={style}
     >
       <div
-        className="bg-(--vscode-editorWidget-background) p-2 grid grid-cols-3 gap-4"
-        style={{ boxShadow: '0 0 8px 0 var(--vscode-widget-shadow)' }}
+        role="toolbar"
+        aria-label="Slide controls"
+        className={cn(
+          'inline-flex items-center gap-1 rounded-2xl px-2 py-1.5 max-w-full',
+          'bg-(--vscode-editorWidget-background)',
+          visible ? 'pointer-events-auto' : 'pointer-events-none',
+        )}
+        style={{
+          border: '1px solid var(--vscode-editorWidget-border, var(--vscode-widget-border))',
+          boxShadow: '0 0 12px 0 var(--vscode-widget-shadow)',
+        }}
       >
-        <div className='flex items-center'>
-          <SlideControl title="Toggle presentation mode" className={`${isPresentationMode ? `bg-(--vscode-statusBarItem-errorBackground) hover:bg-(--vscode-statusBarItem-errorHoverBackground)` : ''}`} icon={<ProjectorIcon className={`w-4 h-4 inline-flex justify-center items-center ${isPresentationMode ? `text-(--vscode-statusBarItem-errorForeground) hover:text-(--vscode-statusBarItem-errorHoverForeground)` : `text-(--vscode-editorWidget-foreground)`}`} />} action={togglePresentationMode} />
+        {/* View tools */}
+        <div className="flex items-center gap-0.5">
+          <SlideControl
+            title="Toggle presentation mode"
+            active={isPresentationMode}
+            icon={<ProjectorIcon className="w-4 h-4" />}
+            ariaPressed={isPresentationMode}
+            action={togglePresentationMode}
+          />
+          <SlideControl
+            title="Toggle presentation view"
+            icon={<WhiteboardIcon className="w-4 h-4" />}
+            action={togglePresentationView}
+          />
           <SlideControl title="Toggle fullscreen" iconName="screen-full" action={toggleFullscreen} />
-          <SlideControl title="Toggle presentation view" icon={<WhiteboardIcon className="w-4 h-4 text-(--vscode-editorWidget-foreground) inline-flex justify-center items-center" />} action={togglePresentationView} />
-          <SlideControl title="Close sidebar" icon={(
-            <div className='relative inline-flex justify-center items-center'>
-              <div className='absolute -top-[2px] -right-[2px] w-2 h-2 bg-(--vscode-editorWidget-foreground) rounded-full inline-flex justify-center items-center'>
-                <Icon name='close' className='text-(--vscode-editorWidget-background)! block' style={{ fontSize: "8px" }} />
-              </div>
-              <Icon name='layout-sidebar-left' className='text-(--vscode-editorWidget-foreground)! inline-flex justify-center items-center' />
-            </div>
-          )} action={closeSidebar} />
-          <SlideControl title="Show demos" iconName='list-unordered' action={focusPanel} />
-          <SlideControl title="Hide controls" iconName='eye-closed' action={hideControls} />
         </div>
 
-        <div className="flex items-center justify-center gap-4">
-          {
-            (previousEnabled || (slides > 1 && currentSlide >= 1)) ? (
-              <SlideControl title="Previous" iconName="arrow-left" action={previous} isSlideControl />
-            ) : (
-              <div style={{ width: "32px" }} />
-            )
-          }
+        <Divider />
 
-          <SlideControl title="Next" iconName="arrow-right" action={next} isSlideControl />
-        </div>
-        <div className="flex items-center justify-end">
-          {slides > 1 && slideOptions && slideOptions.length > 0 ? (
+        {/* Slide navigation */}
+        <div className="flex items-center justify-center gap-1">
+          {showPrevious ? (
+            <SlideControl title="Previous" iconName="arrow-left" action={previous} disabled={!canPrevious} isSlideControl />
+          ) : (
+            <div style={{ width: '32px' }} />
+          )}
+
+          {hasNavigator ? (
             <SlideNavigator
               slides={slides}
               currentSlide={currentSlide}
@@ -197,54 +281,38 @@ export const SlideControls: React.FunctionComponent<React.PropsWithChildren<ISli
               onNavigate={onNavigateToSlide || updateSlideIdx}
               onOpenChange={setIsNavigatorOpen}
             />
-          ) : slides > 1 ? (
-            <div className="slide-info text-sm px-2 py-1 text-(--vscode-editorWidget-foreground)">
-              Slide {currentSlide + 1} of {slides}
+          ) : hasMultipleSlides ? (
+            <div className="slide-info text-sm px-2 py-1 tabular-nums text-(--vscode-editorWidget-foreground)">
+              <span className="font-semibold">{String(currentSlide + 1).padStart(2, '0')}</span>
+              <span className="opacity-50"> / {String(slides).padStart(2, '0')}</span>
             </div>
           ) : null}
+
+          <SlideControl title="Next" iconName="arrow-right" action={next} isSlideControl />
+        </div>
+
+        <Divider />
+
+        {/* Slide tools */}
+        <div className="flex items-center gap-0.5">
+          {showPosition && children}
+
           <SlideControl
             title="Toggle laser pointer"
-            className={`hover:bg-(--vscode-toolbar-hoverBackground) ${laserPointerEnabled ? 'bg-(--vscode-statusBarItem-errorBackground)' : ''}`}
             iconName="record"
-            action={() => {
-              if (onLaserPointerToggle) {
-                onLaserPointerToggle(!laserPointerEnabled);
-              }
-            }}
+            active={laserPointerEnabled}
+            ariaPressed={laserPointerEnabled}
+            action={toggleLaserPointer}
           />
           <SlideControl
-            title={isZoomed ? "Exit zoom" : "Zoom in"}
-            className={`hover:bg-(--vscode-toolbar-hoverBackground) ${isZoomed ? 'bg-(--vscode-statusBarItem-errorBackground)' : ''}`}
-            iconName={isZoomed ? "zoom-out" : "zoom-in"}
-            action={() => {
-              if (onZoomToggle) {
-                onZoomToggle();
-              }
-            }}
+            title={isZoomed ? 'Exit zoom' : 'Zoom in'}
+            iconName={isZoomed ? 'zoom-out' : 'zoom-in'}
+            active={isZoomed}
+            ariaPressed={isZoomed}
+            action={toggleZoom}
           />
 
-          {
-            !isPresentationMode && (
-              <>
-                {showPosition && children}
-                <SlideControl
-                  title="Toggle mouse position"
-                  className='-rotate-90 hover:bg-(--vscode-toolbar-hoverBackground)'
-                  iconName="symbol-ruler"
-                  action={() => {
-                    setShowPosition(prev => !prev);
-                    triggerMouseMove(!showPosition);
-                  }}
-                />
-              </>
-            )
-          }
-
-          {
-            path && !isPresentationMode && (
-              <SlideControl title="Open slide source" iconName="preview" action={openSlideSource} />
-            )
-          }
+          <SlideControlsMenu groups={menuGroups} onOpenChange={setIsMenuOpen} />
         </div>
       </div>
     </div>

--- a/apps/webviews/src/components/preview/SlideControlsMenu.tsx
+++ b/apps/webviews/src/components/preview/SlideControlsMenu.tsx
@@ -1,0 +1,250 @@
+import * as React from 'react';
+import { Icon } from 'vscrui';
+import { cn } from '../../utils/cn';
+import { SlideControl } from './SlideControl';
+
+export interface ISlideMenuItem {
+  id: string;
+  label: string;
+  iconName?: string;
+  icon?: React.ReactNode;
+  onSelect: () => void;
+  /** When a boolean is provided the item becomes a toggle and exposes `aria-checked`. */
+  pressed?: boolean;
+}
+
+export interface ISlideMenuGroup {
+  id: string;
+  /** Optional section header. Headerless groups are separated with a divider. */
+  label?: string;
+  items: ISlideMenuItem[];
+}
+
+export interface ISlideControlsMenuProps {
+  groups: ISlideMenuGroup[];
+  onOpenChange?: (open: boolean) => void;
+}
+
+export const SlideControlsMenu: React.FunctionComponent<ISlideControlsMenuProps> = ({ groups, onOpenChange }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const itemRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const reactId = React.useId();
+  const menuId = `slide-controls-menu-${reactId}`;
+
+  // Flattened item list keeps keyboard navigation independent of the grouping.
+  const items = React.useMemo(() => groups.flatMap((group) => group.items), [groups]);
+
+  React.useEffect(() => {
+    onOpenChange?.(isOpen);
+  }, [isOpen, onOpenChange]);
+
+  const open = React.useCallback((index: number) => {
+    setActiveIndex(index);
+    setIsOpen(true);
+  }, []);
+
+  const close = React.useCallback((returnFocus = true) => {
+    setIsOpen(false);
+    if (returnFocus) {
+      triggerRef.current?.focus();
+    }
+  }, []);
+
+  // Move DOM focus to follow the active item while the menu is open.
+  React.useEffect(() => {
+    if (isOpen) {
+      itemRefs.current[activeIndex]?.focus();
+    }
+  }, [isOpen, activeIndex]);
+
+  // Close when interacting outside of the menu.
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (e: MouseEvent) => {
+      if (wrapperRef.current?.contains(e.target as Node)) {
+        return;
+      }
+      setIsOpen(false);
+    };
+
+    // Capture phase so the menu's Escape wins over the presentation's global Escape handler.
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        close();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown, true);
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown, true);
+      window.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [isOpen, close]);
+
+  const handleTriggerClick = React.useCallback(() => {
+    if (isOpen) {
+      close(false);
+    } else {
+      open(0);
+    }
+  }, [isOpen, open, close]);
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent) => {
+    if (items.length === 0) {
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % items.length);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + items.length) % items.length);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        break;
+      case 'Tab':
+        // Let focus leave the menu naturally without trapping the user.
+        setIsOpen(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (isOpen) {
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      open(0);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      open(items.length - 1);
+    }
+  };
+
+  const handleSelect = (item: ISlideMenuItem) => {
+    item.onSelect();
+    close();
+  };
+
+  // Index across the flattened list so refs/active state line up with keyboard nav.
+  let flatIndex = -1;
+
+  return (
+    <div ref={wrapperRef} className="relative inline-flex" onKeyDown={isOpen ? handleMenuKeyDown : handleTriggerKeyDown}>
+      <SlideControl
+        ref={triggerRef}
+        title="More actions"
+        iconName="ellipsis"
+        active={isOpen}
+        ariaHasPopup="menu"
+        ariaExpanded={isOpen}
+        ariaControls={isOpen ? menuId : undefined}
+        action={handleTriggerClick}
+      />
+
+      {isOpen && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="More slide actions"
+          aria-orientation="vertical"
+          className={cn(
+            'absolute bottom-full right-0 mb-2 z-[60] min-w-[230px] py-1 rounded-lg overflow-hidden',
+            'bg-(--vscode-menu-background) text-(--vscode-menu-foreground)',
+          )}
+          style={{
+            border: '1px solid var(--vscode-menu-border, var(--vscode-editorWidget-border, var(--vscode-widget-border)))',
+            boxShadow: '0 6px 24px var(--vscode-widget-shadow)',
+          }}
+        >
+          {groups.map((group, groupIndex) => {
+            const headerId = `${menuId}-group-${group.id}`;
+            return (
+              <div
+                key={group.id}
+                role="group"
+                aria-labelledby={group.label ? headerId : undefined}
+              >
+                {!group.label && groupIndex > 0 && (
+                  <div
+                    role="separator"
+                    className="my-1 h-px"
+                    style={{ backgroundColor: 'var(--vscode-menu-separatorBackground, var(--vscode-menu-border))' }}
+                  />
+                )}
+                {group.label && (
+                  <div
+                    id={headerId}
+                    className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider opacity-60 select-none"
+                  >
+                    {group.label}
+                  </div>
+                )}
+                {group.items.map((item) => {
+                  flatIndex += 1;
+                  const index = flatIndex;
+                  const isActive = index === activeIndex;
+                  const isToggle = typeof item.pressed === 'boolean';
+                  const iconColor = isActive
+                    ? 'text-(--vscode-menu-selectionForeground)!'
+                    : 'text-(--vscode-menu-foreground)!';
+                  return (
+                    <button
+                      key={item.id}
+                      ref={(el) => {
+                        itemRefs.current[index] = el;
+                      }}
+                      type="button"
+                      role={isToggle ? 'menuitemcheckbox' : 'menuitem'}
+                      aria-checked={isToggle ? item.pressed : undefined}
+                      tabIndex={isActive ? 0 : -1}
+                      onClick={() => handleSelect(item)}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      className={cn(
+                        'w-full flex items-center gap-2.5 px-3 py-1.5 text-sm text-left outline-none',
+                        isActive
+                          ? 'bg-(--vscode-menu-selectionBackground) text-(--vscode-menu-selectionForeground)'
+                          : 'text-(--vscode-menu-foreground)',
+                      )}
+                    >
+                      <span className="inline-flex w-4 h-4 justify-center items-center shrink-0">
+                        {item.iconName && (
+                          <Icon name={item.iconName as never} className={cn(iconColor, 'inline-flex justify-center items-center')} />
+                        )}
+                        {item.icon}
+                      </span>
+                      <span className="flex-1 truncate">{item.label}</span>
+                      {isToggle && item.pressed && (
+                        <Icon name={'check' as never} className={cn(iconColor, 'inline-flex justify-center items-center shrink-0')} />
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/webviews/src/components/preview/SlideNavigator.tsx
+++ b/apps/webviews/src/components/preview/SlideNavigator.tsx
@@ -111,16 +111,14 @@ export const SlideNavigator: React.FunctionComponent<ISlideNavigatorProps> = ({
     <>
       <button
         onClick={toggleOpen}
-        className="flex items-center gap-1 text-sm px-2 py-1 rounded-xs text-(--vscode-editorWidget-foreground) hover:bg-(--vscode-toolbar-hoverBackground) cursor-pointer"
-        title="Navigate to slide"
+        className="flex items-center gap-1 px-2 py-1 rounded-lg tabular-nums text-sm text-(--vscode-editorWidget-foreground) hover:bg-(--vscode-toolbar-hoverBackground) cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--vscode-focusBorder)"
+        title="Go to slide"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-label={`Slide ${currentSlide + 1} of ${slides}. Go to slide`}
       >
-        <span>
-          Slide {currentSlide + 1} / {slides}
-        </span>
-        <Icon
-          name={(isOpen ? 'chevron-down' : 'chevron-up') as never}
-          className="text-(--vscode-editorWidget-foreground)! inline-flex justify-center items-center"
-        />
+        <span className="font-semibold">{String(currentSlide + 1).padStart(2, '0')}</span>
+        <span className="opacity-50">/ {String(slides).padStart(2, '0')}</span>
       </button>
 
       {isOpen && (

--- a/apps/webviews/src/components/preview/index.ts
+++ b/apps/webviews/src/components/preview/index.ts
@@ -7,4 +7,5 @@ export * from './ProjectorIcon';
 export * from './QRPreview';
 export * from './SlideControl';
 export * from './SlideControls';
+export * from './SlideControlsMenu';
 export * from './WhiteboardIcon';

--- a/docs/src/content/docs/slides/index.mdx
+++ b/docs/src/content/docs/slides/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Present your slides
 description: From Markdown to slides - present your slides with Demo Time
-lastmod: 2025-10-01T12:22:17.993Z
+lastmod: 2026-06-12T00:00:00.000Z
 ---
 
 import { Code, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -161,33 +161,38 @@ With this approach, you can seamlessly integrate slides into your demos, making 
 
 ## Slide controls
 
-When presenting slides, you have the following control available:
+When previewing or presenting slides, a compact control bar appears at the bottom of the slide. It is organized into three sections — **view tools**, **slide navigation**, and **slide tools** — and tucks the less-common actions into a **More actions** (`…`) menu so the bar stays uncluttered and adapts to narrow windows.
 
 <Image class="mx-auto" src={slideControlsImg} alt="Slide controls" />
 
-### Left section
+<Aside type="note">
+The control bar is keyboard and screen reader friendly. Every button is reachable with `Tab` and exposes a descriptive label, toggle buttons announce their on/off state, and the **More actions** menu opens with `Enter`/`Space` (or the arrow keys) and is navigated with the arrow, `Home`, `End`, and `Escape` keys.
+</Aside>
 
-- **Toggle presentation mode**: This toggles the presentation mode, which allows you to use your clicker or keyboard to navigate through your slides.
-- **Fullscreen mode**: Toggles the fullscreen mode from Visual Studio Code.
-- **Presentation view**: This toggles the presentation view, which hides the status bar, tabs, and activity bar to provide a distraction-free experience. You can also use the `setPresentationView` and `unsetPresentationView` actions to control the presentation view programmatically, or from the `Demo Time: Toggle presentation view (hides status bar, tabs, and activity bar)` command.
-- **Close side panel**: Closes the side panel to provide more space for your slides.
-- **Open the Demo Time panel**: Opens the Demo Time panel to access your demos and slides.
-- **Hide controls**: Hides the slide controls and mouse, allowing you to focus on your presentation without distractions.
+### View tools
 
-### Middle section
+- **Toggle presentation mode**: Toggles presentation mode, which allows you to use your clicker or keyboard to navigate through your slides. The button is highlighted while presentation mode is active.
+- **Toggle presentation view**: Toggles the presentation view, which hides VS Code UI areas (status bar, tabs, activity bar, …) for a distraction-free experience. You can also use the `setPresentationView` and `unsetPresentationView` actions, or the `Demo Time: Toggle presentation view (hides status bar, tabs, and activity bar)` command.
+- **Toggle fullscreen**: Toggles Visual Studio Code's fullscreen mode.
 
-- **Previous move**: Triggers the previous move (only if the `demo-time.previousEnabled` setting is enabled or when using grouped slides).
-- **Next move**: Triggers the next move.
+### Slide navigation
 
-### Right section
+- **Previous**: Triggers the previous move (only if the `demo-time.previousEnabled` setting is enabled or when using grouped slides).
+- **Slide counter**: Shows the current slide and total (for example `01 / 05`). When slide thumbnails are available, selecting it opens the **Go to slide** overview so you can jump straight to any slide.
+- **Next**: Triggers the next move.
 
-- **Toggle laser pointer**: Toggles the laser pointer, which can be used to highlight specific areas on your slides during the presentation.
-- **Toggle zoom**: Toggles the zoom feature, allowing you to zoom in on specific parts of your slides for better visibility.
+### Slide tools
 
-The following actions are only available when you are not in presentation mode:
-
-- **Toggle mouse position**: Toggles the mouse position overlay on the slide, which can be useful to position elements on your slides.
-- **Open slide source**: Opens the source file of the slide in the editor, allowing you to edit the slide content directly.
+- **Toggle laser pointer**: Toggles the laser pointer to highlight specific areas on your slides. The button is highlighted while the laser pointer is active.
+- **Toggle zoom**: Toggles the zoom feature to zoom in on parts of your slides. The button is highlighted while zoom is active.
+- **More actions** (`…`): Opens a menu with the remaining actions, grouped for discoverability:
+  - **Slide** _(only available when you are not in presentation mode)_
+    - **Mouse position**: Toggles the mouse position overlay on the slide, which can be useful to position elements on your slides.
+    - **Open slide source**: Opens the source file of the slide in the editor, allowing you to edit the slide content directly.
+  - **Workspace**
+    - **Show demos**: Opens the Demo Time panel to access your demos and slides.
+    - **Close sidebar**: Closes the side bar to provide more space for your slides.
+  - **Hide controls**: Hides the slide controls and mouse, allowing you to focus on your presentation without distractions.
 
 ## Auto-advancing to the next slide
 


### PR DESCRIPTION
Resolves #409.

## What changed

Redesigns the slide preview/presentation **control bar** from the old full-width three-column grid into a compact, centered **pill** with three clearly separated zones, and moves the secondary actions into an accessible overflow **More actions (`…`)** menu — matching the mockup in the issue.

**Layout (left → right):**
- **View tools** — toggle presentation mode · presentation view · fullscreen
- **Navigation** — previous · `01 / 05` counter (opens the *Go to slide* thumbnail grid) · next
- **Slide tools** — laser pointer · zoom · **More actions (`…`)**

**Overflow menu** (improves discoverability, per the issue) groups:
- **Slide** *(non-presentation only)* — Mouse position (toggle), Open slide source
- **Workspace** — Show demos, Close sidebar
- **Hide controls**

## Why

The previous bar stretched the full width of the preview and surfaced every action inline, which was visually heavy and hard to scan. The issue asks for a modernized, consistent design, better discoverability for secondary actions, and validated accessibility/responsiveness.

## Notes for reviewers

- **New component** `SlideControlsMenu.tsx` is fully keyboard accessible: open with `Enter`/`Space`/arrows, navigate with arrow/`Home`/`End`, `Escape` closes and returns focus to the trigger (capture-phase so it wins over the presentation's global `Esc`), click-outside dismisses. Uses `role="menu"` / `menuitem` / `menuitemcheckbox` with `aria-checked` for toggles.
- `SlideControl` is now `forwardRef`, has a focus-visible ring, `aria-label`/`aria-pressed`, and a unified **accent** active state (Demo Time gold) for toggled controls and the open menu — replacing the previous red toggle treatment for a consistent design language.
- Toggle semantics, navigation, auto-advance, and the *Go to slide* grid are all preserved; only the laser/zoom/presentation active styling changed color (red → accent).
- The bar is a centered, max-width pill, so it adapts to narrow panels far better than the old `w-full` grid.
- Verified: `tsc` (preview scope) and `vite build` pass with no new errors; rendered the real markup against the compiled CSS + codicon font to confirm it matches the mockup at desktop and ~400px widths.
- Docs updated in `docs/src/content/docs/slides/index.mdx`. ⚠️ The doc still references the old screenshot asset (`slide-controls-1.6.0.webp`) — that binary should be re-captured from VS Code to reflect the new bar.

## Test plan

- [ ] Open a slide preview; confirm the pill bar renders with the three zones and dividers.
- [ ] Open the `…` menu via mouse and keyboard; navigate with arrows, toggle *Mouse position*, select *Open slide source*, `Esc` to close.
- [ ] Toggle laser pointer / zoom / presentation mode and confirm the accent active state.
- [ ] Verify behavior in presentation mode (Slide group hidden) and on a single-slide deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign slide controls into a compact pill bar with an overflow menu
> - Rebuilds [SlideControls.tsx](https://github.com/estruyf/vscode-demo-time/pull/410/files#diff-20551a066e36f2202299afa4bb3e4c343d76ddc089a8bd5d7e1aa304135d58fc) as a grouped toolbar with visual dividers, moving secondary actions (mouse position, demos, sidebar, hide controls) into a new overflow menu.
> - Adds [SlideControlsMenu.tsx](https://github.com/estruyf/vscode-demo-time/pull/410/files#diff-fddeee7d526322dbf6ad226747c1a6f09a3d80773ba22c04dca125cafc34f149), a keyboard-accessible ARIA-compliant overflow menu with grouped actions, toggle support (`menuitemcheckbox`), and full keyboard navigation (Arrow keys, Home/End, Escape, Tab).
> - Updates [SlideControl.tsx](https://github.com/estruyf/vscode-demo-time/pull/410/files#diff-2305e9b6363933bb1cd4abe6fd32d958d9cb02616138871285eef91e56b5b62d) to support ref forwarding, `active` visual state, `aria-pressed`/`aria-expanded`/`aria-haspopup` passthrough, and improved focus ring and disabled styles.
> - Changes the slide counter to zero-padded two-digit format (e.g. `01 / 05`) and makes it the navigator trigger; removes the chevron icon from [SlideNavigator.tsx](https://github.com/estruyf/vscode-demo-time/pull/410/files#diff-932f98f40ebd229c4b6a7d4d20f5c5cf5d721883a9ce6ffd564bf6121a7bfb39).
> - Behavioral Change: the mouse position overlay now renders whenever `showPosition` is true, regardless of presentation mode; the Previous button renders disabled when unavailable rather than using a spacer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b52b2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned slide control bar with a compact "More actions" overflow menu consolidating auxiliary toggles and workspace options.
  * Enhanced accessibility support with improved ARIA attributes and keyboard navigation.

* **Documentation**
  * Updated slide controls documentation to reflect the new control bar layout and action organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->